### PR TITLE
Initial K8s Controller Implementation for Open Terminal Orchestration

### DIFF
--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -1,0 +1,11 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir kopf kubernetes
+
+COPY terminals/controller.py /app/controller.py
+
+USER 65534:65534
+
+ENTRYPOINT ["kopf", "run", "/app/controller.py", "--verbose"]

--- a/Dockerfile.orchestrator
+++ b/Dockerfile.orchestrator
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY pyproject.toml README.md /app/
+COPY terminals/ /app/terminals/
+
+RUN pip install --no-cache-dir /app[orchestrator]
+
+USER 65534:65534
+
+EXPOSE 8080
+
+ENTRYPOINT ["python", "-m", "terminals.app"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,149 @@ Multi-tenant terminal orchestrator for [Open Terminal](https://github.com/open-w
 
 Provisions and manages isolated Open Terminal containers per user, with tenant scoping and a single authenticated API entry point.
 
+## Kubernetes Controller
+
+The Kubernetes Controller automatically provisions and manages per-user [Open Terminal](https://github.com/open-webui/open-terminal) pods inside a Kubernetes cluster.
+
+### Architecture
+
+```
+Browser → Open WebUI → Orchestrator → Controller → Per-user Terminal Pod
+```
+
+| Component | Description |
+|---|---|
+| **Terminal CRD** (`terminals.open-webui.com/v1alpha1`) | Declares a per-user terminal instance as a Kubernetes custom resource. |
+| **Controller** (`controller.py`, kopf) | Watches Terminal CRDs and reconciles a Pod, Service, Secret, and PVC for each one. Culls idle terminals after a configurable timeout. |
+| **Orchestrator** (`app.py`, FastAPI) | Single authenticated entry point. Receives requests from Open WebUI, ensures the user's Terminal CRD exists, waits for the pod to become ready, and proxies HTTP/WebSocket traffic to it. Also serves a cached `/openapi.json` so Open WebUI can discover terminal tools. |
+
+### Prerequisites
+
+- Kubernetes cluster (v1.24+)
+- `kubectl` configured for the target cluster
+- Container images built and accessible (see below)
+- Open WebUI configured with `TERMINAL_SERVER_CONNECTIONS`
+
+### Building Images
+
+```bash
+# From the terminals/ directory
+docker build -f Dockerfile.controller -t terminals-controller:latest .
+docker build -f Dockerfile.orchestrator -t terminals-orchestrator:latest .
+```
+
+### Manual Deployment
+
+1. **Apply the CRD and RBAC resources:**
+
+```bash
+kubectl apply -f manifests/crd.yaml
+kubectl apply -f manifests/rbac.yaml
+```
+
+2. **Deploy the controller and orchestrator** (adjust image names/namespaces as needed):
+
+```yaml
+# controller deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: terminals-controller
+  namespace: open-webui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: terminals-controller
+  template:
+    metadata:
+      labels:
+        app: terminals-controller
+    spec:
+      serviceAccountName: terminals-controller
+      containers:
+        - name: controller
+          image: terminals-controller:latest
+          env:
+            - name: TERMINAL_NAMESPACE
+              value: open-webui
+---
+# orchestrator deployment + service
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: terminals-orchestrator
+  namespace: open-webui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: terminals-orchestrator
+  template:
+    metadata:
+      labels:
+        app: terminals-orchestrator
+    spec:
+      serviceAccountName: terminals-controller
+      containers:
+        - name: orchestrator
+          image: terminals-orchestrator:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: TERMINAL_NAMESPACE
+              value: open-webui
+            - name: TERMINAL_API_KEY
+              value: "your-secret-key"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: terminals-orchestrator
+  namespace: open-webui
+spec:
+  selector:
+    app: terminals-orchestrator
+  ports:
+    - port: 8080
+      targetPort: 8080
+```
+
+3. **Configure Open WebUI** to point at the orchestrator:
+
+```
+TERMINAL_SERVER_CONNECTIONS='[{"url":"http://terminals-orchestrator:8080","key":"your-secret-key"}]'
+```
+
+### Helm Chart (not released to main yet)
+
+A Helm sub-chart will be available in the Open WebUI Helm Charts and is wired into the Open WebUI parent chart as an optional dependency. Enable it in your Open WebUI values:
+
+```yaml
+terminals:
+  enabled: true
+  orchestrator:
+    apiKey: "your-secret-key" # TODO: Update to secret ref
+```
+
+### Configuration
+
+The orchestrator and controller are configured via environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `TERMINAL_NAMESPACE` | `open-webui` | Namespace for Terminal CRDs and pods |
+| `TERMINAL_DEFAULT_IMAGE` | `ghcr.io/open-webui/open-terminal:latest` | Container image for terminal pods |
+| `TERMINAL_DEFAULT_CPU_REQUEST` | `100m` | CPU request per terminal pod |
+| `TERMINAL_DEFAULT_MEMORY_REQUEST` | `256Mi` | Memory request per terminal pod |
+| `TERMINAL_DEFAULT_CPU_LIMIT` | `1` | CPU limit per terminal pod |
+| `TERMINAL_DEFAULT_MEMORY_LIMIT` | `1Gi` | Memory limit per terminal pod |
+| `TERMINAL_DEFAULT_IDLE_TIMEOUT` | `30` | Minutes of inactivity before a terminal is culled |
+| `TERMINAL_DEFAULT_PERSISTENCE_ENABLED` | `true` | Attach a PVC to each terminal pod |
+| `TERMINAL_DEFAULT_PERSISTENCE_SIZE` | `1Gi` | PVC size per terminal |
+| `TERMINAL_DEFAULT_STORAGE_CLASS` | _(cluster default)_ | StorageClass for terminal PVCs |
+| `TERMINAL_API_KEY` | _(required)_ | Shared secret between Open WebUI and the orchestrator |
+
 ## License
 
 [Open WebUI Enterprise License](LICENSE) — see LICENSE for details.

--- a/kubernetes-controller/app.py
+++ b/kubernetes-controller/app.py
@@ -1,0 +1,391 @@
+"""Terminals Orchestrator — FastAPI app that provisions and proxies to per-user Open Terminal pods.
+
+Open WebUI connects to this as a single ``TERMINAL_SERVER_CONNECTIONS`` entry.
+The orchestrator:
+  1. Extracts ``X-User-Id`` from the incoming request (set by Open WebUI's proxy)
+  2. Ensures a Terminal CRD exists for that user (creates one on first request)
+  3. Waits for the terminal pod to become Ready
+  4. Proxies the request to the user's Open Terminal pod
+  5. Touches ``lastActivityAt`` on each request to prevent idle culling
+"""
+
+import asyncio
+import logging
+
+import aiohttp
+import uvicorn
+from fastapi import FastAPI, Request, Response, WebSocket
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse, StreamingResponse
+from starlette.background import BackgroundTask
+
+from terminals.config import API_KEY, HOST, PORT, PROVISION_TIMEOUT_SECONDS
+from terminals.k8s import (
+    delete_terminal,
+    ensure_terminal,
+    get_api_key,
+    get_terminal,
+    touch_activity,
+    wait_for_ready,
+)
+
+log = logging.getLogger(__name__)
+
+app = FastAPI(
+    title="Terminals Orchestrator",
+    docs_url=None,
+    redoc_url=None,
+    openapi_url=None,  # Disable built-in OpenAPI — let the catch-all proxy serve the terminal's spec
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+STREAMING_CONTENT_TYPES = ("application/octet-stream", "image/", "application/pdf")
+STRIPPED_RESPONSE_HEADERS = frozenset(
+    ("transfer-encoding", "connection", "content-encoding", "content-length")
+)
+
+
+# ---------------------------------------------------------------------------
+# Auth helper
+# ---------------------------------------------------------------------------
+
+
+def _authenticate(request: Request) -> bool:
+    """Validate the bearer token from Open WebUI matches our API key."""
+    if not API_KEY:
+        return True  # No key configured — accept all (dev mode)
+    auth = request.headers.get("authorization", "")
+    return auth == f"Bearer {API_KEY}"
+
+
+def _get_user_id(request: Request) -> str | None:
+    """Extract user ID from the X-User-Id header set by Open WebUI's terminal proxy."""
+    return request.headers.get("x-user-id")
+
+
+# ---------------------------------------------------------------------------
+# Resolve user terminal — get or create, wait for ready
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_terminal(user_id: str) -> tuple[str, str] | None:
+    """Ensure a terminal exists and is running. Returns (service_url, api_key) or None."""
+    terminal = ensure_terminal(user_id)
+    status = terminal.get("status") or {}
+    phase = status.get("phase")
+
+    if phase != "Running":
+        terminal = await wait_for_ready(user_id, timeout=PROVISION_TIMEOUT_SECONDS)
+        if terminal is None:
+            return None
+        status = terminal.get("status") or {}
+
+    service_url = status.get("serviceUrl")
+    secret_name = status.get("apiKeySecret")
+    if not service_url or not secret_name:
+        return None
+
+    api_key = get_api_key(secret_name)
+    if not api_key:
+        return None
+
+    return service_url, api_key
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@app.get("/openapi.json", include_in_schema=False)
+async def openapi_spec():
+    """Proxy the Open Terminal OpenAPI spec from any running terminal pod.
+
+    Open WebUI fetches this to discover available tools. This endpoint
+    doesn't require auth or X-User-Id since it returns a static schema.
+    The spec is cached after the first successful fetch.
+    """
+    global _cached_openapi_spec
+    if _cached_openapi_spec is not None:
+        return JSONResponse(_cached_openapi_spec)
+
+    # Find any Running terminal to fetch the spec from
+    from terminals.k8s import _list_running_terminals
+    terminals = _list_running_terminals()
+    if not terminals:
+        return JSONResponse(
+            {"error": "No running terminals available to fetch spec from"},
+            status_code=503,
+        )
+
+    for terminal in terminals:
+        status = terminal.get("status") or {}
+        service_url = status.get("serviceUrl")
+        secret_name = status.get("apiKeySecret")
+        if not service_url or not secret_name:
+            continue
+        api_key = get_api_key(secret_name)
+        if not api_key:
+            continue
+
+        try:
+            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+                async with session.get(
+                    f"{service_url.rstrip('/')}/openapi.json",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                ) as resp:
+                    if resp.status == 200:
+                        _cached_openapi_spec = await resp.json()
+                        return JSONResponse(_cached_openapi_spec)
+        except Exception:
+            continue
+
+    return JSONResponse({"error": "Could not fetch spec from any terminal"}, status_code=503)
+
+
+_cached_openapi_spec: dict | None = None
+
+
+@app.get("/")
+async def get_status(request: Request):
+    """Return the terminal status for the authenticated user."""
+    if not _authenticate(request):
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+
+    user_id = _get_user_id(request)
+    if not user_id:
+        return JSONResponse({"error": "X-User-Id header required"}, status_code=400)
+
+    terminal = get_terminal(user_id)
+    if terminal is None:
+        return {"status": "none", "phase": None}
+
+    status = terminal.get("status") or {}
+    return {
+        "status": "exists",
+        "phase": status.get("phase"),
+        "serviceUrl": status.get("serviceUrl"),
+        "lastActivityAt": status.get("lastActivityAt"),
+    }
+
+
+@app.delete("/")
+async def stop_terminal(request: Request):
+    """Explicitly stop and delete a user's terminal."""
+    if not _authenticate(request):
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+
+    user_id = _get_user_id(request)
+    if not user_id:
+        return JSONResponse({"error": "X-User-Id header required"}, status_code=400)
+
+    deleted = delete_terminal(user_id)
+    return {"deleted": deleted}
+
+
+PROXY_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"]
+
+
+@app.api_route("/{path:path}", methods=PROXY_METHODS, include_in_schema=False)
+async def proxy_to_terminal(path: str, request: Request):
+    """Proxy any request to the user's Open Terminal pod."""
+    if not _authenticate(request):
+        return JSONResponse({"error": "Unauthorized"}, status_code=401)
+
+    user_id = _get_user_id(request)
+    if not user_id:
+        return JSONResponse({"error": "X-User-Id header required"}, status_code=400)
+
+    resolved = await _resolve_terminal(user_id)
+    if resolved is None:
+        return JSONResponse(
+            {"error": "Terminal not ready. Try again shortly."}, status_code=503
+        )
+
+    service_url, api_key = resolved
+    target_url = f"{service_url.rstrip('/')}/{path}"
+    if request.query_params:
+        target_url += f"?{request.query_params}"
+
+    # Touch activity asynchronously
+    asyncio.create_task(asyncio.to_thread(touch_activity, user_id))
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "X-User-Id": user_id,
+    }
+    content_type = request.headers.get("content-type")
+    if content_type:
+        headers["Content-Type"] = content_type
+
+    body = await request.body()
+    session = aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=300, connect=10),
+    )
+
+    try:
+        upstream_response = await session.request(
+            method=request.method,
+            url=target_url,
+            headers=headers,
+            data=body or None,
+        )
+
+        upstream_content_type = upstream_response.headers.get("content-type", "")
+        filtered_headers = {
+            k: v
+            for k, v in upstream_response.headers.items()
+            if k.lower() not in STRIPPED_RESPONSE_HEADERS
+        }
+
+        if any(t in upstream_content_type for t in STREAMING_CONTENT_TYPES):
+
+            async def cleanup():
+                await upstream_response.release()
+                await session.close()
+
+            return StreamingResponse(
+                content=upstream_response.content.iter_any(),
+                status_code=upstream_response.status,
+                headers=filtered_headers,
+                background=BackgroundTask(cleanup),
+            )
+
+        response_body = await upstream_response.read()
+        status_code = upstream_response.status
+        await upstream_response.release()
+        await session.close()
+
+        return Response(
+            content=response_body, status_code=status_code, headers=filtered_headers
+        )
+
+    except Exception as error:
+        await session.close()
+        log.exception("Proxy error for user %s: %s", user_id, error)
+        return JSONResponse(
+            {"error": f"Terminal proxy error: {error}"}, status_code=502
+        )
+
+
+# ---------------------------------------------------------------------------
+# WebSocket proxy
+# ---------------------------------------------------------------------------
+
+
+@app.websocket("/api/terminals/{session_id}")
+async def ws_terminal(ws: WebSocket, session_id: str):
+    """Proxy a WebSocket terminal session to the user's Open Terminal pod.
+
+    Uses first-message auth: ``{"type": "auth", "token": "<orchestrator_api_key>"}``.
+    The ``user_id`` is passed as a query parameter by Open WebUI's WS proxy.
+    """
+    await ws.accept()
+
+    import json
+
+    # First message: auth from Open WebUI's WS proxy
+    try:
+        raw = await asyncio.wait_for(ws.receive_text(), timeout=10.0)
+        payload = json.loads(raw)
+        if payload.get("type") != "auth":
+            await ws.close(code=4001, reason="Expected auth message")
+            return
+        token = payload.get("token", "")
+        if API_KEY and token != API_KEY:
+            await ws.close(code=4001, reason="Invalid token")
+            return
+    except (asyncio.TimeoutError, json.JSONDecodeError):
+        await ws.close(code=4001, reason="Auth timeout or invalid payload")
+        return
+
+    # Get user_id from query params (set by Open WebUI's WS proxy)
+    user_id = ws.query_params.get("user_id")
+    if not user_id:
+        await ws.close(code=4001, reason="user_id query parameter required")
+        return
+
+    resolved = await _resolve_terminal(user_id)
+    if resolved is None:
+        await ws.close(code=4003, reason="Terminal not ready")
+        return
+
+    service_url, api_key = resolved
+
+    # Touch activity
+    asyncio.create_task(asyncio.to_thread(touch_activity, user_id))
+
+    # Connect to the upstream Open Terminal WebSocket
+    ws_url = service_url.replace("http://", "ws://").replace("https://", "wss://")
+    upstream_url = f"{ws_url.rstrip('/')}/api/terminals/{session_id}"
+
+    session = aiohttp.ClientSession()
+    try:
+        async with session.ws_connect(upstream_url) as upstream:
+            # Auth to upstream Open Terminal
+            await upstream.send_str(json.dumps({"type": "auth", "token": api_key}))
+
+            async def client_to_upstream():
+                try:
+                    while True:
+                        msg = await ws.receive()
+                        if msg["type"] == "websocket.disconnect":
+                            break
+                        elif "bytes" in msg and msg["bytes"]:
+                            await upstream.send_bytes(msg["bytes"])
+                        elif "text" in msg and msg["text"]:
+                            await upstream.send_str(msg["text"])
+                except Exception:
+                    pass
+
+            async def upstream_to_client():
+                try:
+                    async for msg in upstream:
+                        if msg.type == aiohttp.WSMsgType.BINARY:
+                            await ws.send_bytes(msg.data)
+                        elif msg.type == aiohttp.WSMsgType.TEXT:
+                            await ws.send_text(msg.data)
+                        elif msg.type in (
+                            aiohttp.WSMsgType.CLOSE,
+                            aiohttp.WSMsgType.ERROR,
+                        ):
+                            break
+                except Exception:
+                    pass
+
+            await asyncio.gather(
+                client_to_upstream(), upstream_to_client(), return_exceptions=True
+            )
+    except Exception as e:
+        log.exception("WebSocket proxy error for user %s: %s", user_id, e)
+    finally:
+        await session.close()
+        try:
+            await ws.close()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main():
+    uvicorn.run(app, host=HOST, port=PORT, log_level="info")
+
+
+if __name__ == "__main__":
+    main()

--- a/kubernetes-controller/config.py
+++ b/kubernetes-controller/config.py
@@ -1,0 +1,42 @@
+"""Configuration for the Terminals orchestrator loaded from environment variables."""
+
+import os
+
+# Kubernetes namespace where Terminal CRDs and pods are created.
+TERMINAL_NAMESPACE: str = os.environ.get("TERMINAL_NAMESPACE", "open-webui")
+
+# Default image for spawned Open Terminal containers.
+DEFAULT_IMAGE: str = os.environ.get(
+    "TERMINAL_DEFAULT_IMAGE", "ghcr.io/open-webui/open-terminal:latest"
+)
+
+# Default resource requests/limits for terminal pods.
+DEFAULT_CPU_REQUEST: str = os.environ.get("TERMINAL_DEFAULT_CPU_REQUEST", "100m")
+DEFAULT_MEMORY_REQUEST: str = os.environ.get("TERMINAL_DEFAULT_MEMORY_REQUEST", "256Mi")
+DEFAULT_CPU_LIMIT: str = os.environ.get("TERMINAL_DEFAULT_CPU_LIMIT", "1")
+DEFAULT_MEMORY_LIMIT: str = os.environ.get("TERMINAL_DEFAULT_MEMORY_LIMIT", "1Gi")
+
+# Idle timeout in minutes before a terminal pod is culled.
+DEFAULT_IDLE_TIMEOUT_MINUTES: int = int(
+    os.environ.get("TERMINAL_DEFAULT_IDLE_TIMEOUT", "30")
+)
+
+# Persistence defaults.
+DEFAULT_PERSISTENCE_ENABLED: bool = (
+    os.environ.get("TERMINAL_DEFAULT_PERSISTENCE_ENABLED", "true").lower() == "true"
+)
+DEFAULT_PERSISTENCE_SIZE: str = os.environ.get("TERMINAL_DEFAULT_PERSISTENCE_SIZE", "1Gi")
+DEFAULT_STORAGE_CLASS: str = os.environ.get("TERMINAL_DEFAULT_STORAGE_CLASS", "")
+
+# API key for authenticating requests from Open WebUI to the orchestrator.
+# When deployed via Helm, this is set from a Secret.
+API_KEY: str = os.environ.get("TERMINALS_API_KEY", "")
+
+# How long to wait (seconds) for a terminal pod to become ready before timing out.
+PROVISION_TIMEOUT_SECONDS: int = int(
+    os.environ.get("TERMINAL_PROVISION_TIMEOUT", "120")
+)
+
+# Host and port for the orchestrator server.
+HOST: str = os.environ.get("TERMINALS_HOST", "0.0.0.0")
+PORT: int = int(os.environ.get("TERMINALS_PORT", "8080"))

--- a/kubernetes-controller/controller.py
+++ b/kubernetes-controller/controller.py
@@ -1,0 +1,515 @@
+"""Kubernetes controller for Terminal CRDs.
+
+Uses `kopf` to watch ``terminals.open-webui.com/v1alpha1`` resources and
+reconcile the underlying Pod, Service, PVC, and Secret for each user terminal.
+"""
+
+import kopf
+import kubernetes
+import logging
+import secrets
+import string
+from datetime import datetime, timezone
+
+log = logging.getLogger(__name__)
+
+API_GROUP = "open-webui.com"
+API_VERSION = "v1alpha1"
+RESOURCE_PLURAL = "terminals"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _generate_api_key(length: int = 48) -> str:
+    alphabet = string.ascii_letters + string.digits
+    return "sk-" + "".join(secrets.choice(alphabet) for _ in range(length))
+
+
+def _resource_name(name: str, suffix: str) -> str:
+    """Derive child resource names from the Terminal CR name."""
+    return f"{name}-{suffix}"
+
+
+def _build_pod_manifest(
+    name: str,
+    namespace: str,
+    spec: dict,
+    api_key: str,
+    owner_ref: dict,
+    pvc_name: str | None,
+) -> dict:
+    """Build the Pod manifest for an Open Terminal instance."""
+    image = spec.get("image", "ghcr.io/open-webui/open-terminal:latest")
+    resources_spec = spec.get("resources", {})
+    packages = spec.get("packages", [])
+    pip_packages = spec.get("pipPackages", [])
+
+    env = [
+        {"name": "OPEN_TERMINAL_API_KEY", "value": api_key},
+        {"name": "OPEN_TERMINAL_HOST", "value": "0.0.0.0"},
+        {"name": "OPEN_TERMINAL_PORT", "value": "8000"},
+    ]
+    if packages:
+        env.append({"name": "OPEN_TERMINAL_PACKAGES", "value": " ".join(packages)})
+    if pip_packages:
+        env.append(
+            {"name": "OPEN_TERMINAL_PIP_PACKAGES", "value": " ".join(pip_packages)}
+        )
+
+    volume_mounts = []
+    volumes = []
+    if pvc_name:
+        volume_mounts.append({"name": "workspace", "mountPath": "/workspace"})
+        volumes.append(
+            {
+                "name": "workspace",
+                "persistentVolumeClaim": {"claimName": pvc_name},
+            }
+        )
+
+    container = {
+        "name": "open-terminal",
+        "image": image,
+        "ports": [{"containerPort": 8000, "name": "http", "protocol": "TCP"}],
+        "env": env,
+        "volumeMounts": volume_mounts,
+        "readinessProbe": {
+            "httpGet": {"path": "/health", "port": 8000},
+            "initialDelaySeconds": 3,
+            "periodSeconds": 5,
+        },
+        "livenessProbe": {
+            "httpGet": {"path": "/health", "port": 8000},
+            "initialDelaySeconds": 10,
+            "periodSeconds": 15,
+        },
+    }
+
+    requests = resources_spec.get("requests", {})
+    limits = resources_spec.get("limits", {})
+    if requests or limits:
+        container["resources"] = {}
+        if requests:
+            container["resources"]["requests"] = requests
+        if limits:
+            container["resources"]["limits"] = limits
+
+    return {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": _resource_name(name, "pod"),
+            "namespace": namespace,
+            "labels": {
+                "app.kubernetes.io/name": "open-terminal",
+                "app.kubernetes.io/instance": name,
+                "app.kubernetes.io/managed-by": "terminals-controller",
+                "open-webui.com/terminal": name,
+            },
+            "ownerReferences": [owner_ref],
+        },
+        "spec": {
+            "containers": [container],
+            "volumes": volumes,
+            "restartPolicy": "Always",
+            "enableServiceLinks": False,
+            "automountServiceAccountToken": False,
+        },
+    }
+
+
+def _build_service_manifest(
+    name: str, namespace: str, owner_ref: dict
+) -> dict:
+    return {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+            "name": _resource_name(name, "svc"),
+            "namespace": namespace,
+            "labels": {
+                "app.kubernetes.io/name": "open-terminal",
+                "app.kubernetes.io/instance": name,
+                "app.kubernetes.io/managed-by": "terminals-controller",
+            },
+            "ownerReferences": [owner_ref],
+        },
+        "spec": {
+            "type": "ClusterIP",
+            "selector": {"open-webui.com/terminal": name},
+            "ports": [
+                {
+                    "name": "http",
+                    "port": 8000,
+                    "targetPort": 8000,
+                    "protocol": "TCP",
+                }
+            ],
+        },
+    }
+
+
+def _build_secret_manifest(
+    name: str, namespace: str, api_key: str, owner_ref: dict
+) -> dict:
+    import base64
+
+    return {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {
+            "name": _resource_name(name, "apikey"),
+            "namespace": namespace,
+            "labels": {
+                "app.kubernetes.io/name": "open-terminal",
+                "app.kubernetes.io/instance": name,
+                "app.kubernetes.io/managed-by": "terminals-controller",
+            },
+            "ownerReferences": [owner_ref],
+        },
+        "type": "Opaque",
+        "data": {
+            "api-key": base64.b64encode(api_key.encode()).decode(),
+        },
+    }
+
+
+def _build_pvc_manifest(
+    name: str, namespace: str, spec: dict, owner_ref: dict
+) -> dict:
+    persistence = spec.get("persistence", {})
+    size = persistence.get("size", "1Gi")
+    storage_class = persistence.get("storageClass", "")
+
+    pvc = {
+        "apiVersion": "v1",
+        "kind": "PersistentVolumeClaim",
+        "metadata": {
+            "name": _resource_name(name, "pvc"),
+            "namespace": namespace,
+            "labels": {
+                "app.kubernetes.io/name": "open-terminal",
+                "app.kubernetes.io/instance": name,
+                "app.kubernetes.io/managed-by": "terminals-controller",
+            },
+            "ownerReferences": [owner_ref],
+        },
+        "spec": {
+            "accessModes": ["ReadWriteOnce"],
+            "resources": {"requests": {"storage": size}},
+        },
+    }
+    if storage_class:
+        pvc["spec"]["storageClassName"] = storage_class
+    return pvc
+
+
+def _owner_reference(body: dict) -> dict:
+    return {
+        "apiVersion": f"{API_GROUP}/{API_VERSION}",
+        "kind": "Terminal",
+        "name": body["metadata"]["name"],
+        "uid": body["metadata"]["uid"],
+        "controller": True,
+        "blockOwnerDeletion": True,
+    }
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _set_condition(
+    status: dict, cond_type: str, cond_status: str, reason: str = "", message: str = ""
+) -> list:
+    conditions = list(status.get("conditions") or [])
+    for c in conditions:
+        if c["type"] == cond_type:
+            c["status"] = cond_status
+            c["lastTransitionTime"] = _now_iso()
+            c["reason"] = reason
+            c["message"] = message
+            return conditions
+    conditions.append(
+        {
+            "type": cond_type,
+            "status": cond_status,
+            "lastTransitionTime": _now_iso(),
+            "reason": reason,
+            "message": message,
+        }
+    )
+    return conditions
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+
+@kopf.on.startup()
+def configure(settings: kopf.OperatorSettings, **_):
+    settings.posting.level = logging.WARNING
+    settings.persistence.finalizer = "terminals.open-webui.com/finalizer"
+
+
+@kopf.on.create(API_GROUP, API_VERSION, RESOURCE_PLURAL)
+async def on_create(body, spec, name, namespace, patch, **_):
+    """Create all child resources for a new Terminal CR."""
+    log.info("Creating terminal %s/%s for user %s", namespace, name, spec.get("userId"))
+
+    owner_ref = _owner_reference(body)
+    api_key = _generate_api_key()
+    core_v1 = kubernetes.client.CoreV1Api()
+
+    # -- Status: Provisioning
+    patch.status["phase"] = "Provisioning"
+    patch.status["lastActivityAt"] = _now_iso()
+    patch.status["conditions"] = _set_condition(
+        {}, "Ready", "False", "Provisioning", "Creating child resources"
+    )
+
+    # -- PVC (if persistence enabled)
+    persistence = spec.get("persistence", {})
+    pvc_name = None
+    if persistence.get("enabled", True):
+        pvc_name = _resource_name(name, "pvc")
+        pvc_manifest = _build_pvc_manifest(name, namespace, spec, owner_ref)
+        try:
+            core_v1.create_namespaced_persistent_volume_claim(
+                namespace=namespace, body=pvc_manifest
+            )
+            log.info("Created PVC %s/%s", namespace, pvc_name)
+        except kubernetes.client.exceptions.ApiException as e:
+            if e.status == 409:
+                log.info("PVC %s/%s already exists", namespace, pvc_name)
+            else:
+                raise
+
+    # -- Secret (API key)
+    secret_name = _resource_name(name, "apikey")
+    secret_manifest = _build_secret_manifest(name, namespace, api_key, owner_ref)
+    try:
+        core_v1.create_namespaced_secret(namespace=namespace, body=secret_manifest)
+        log.info("Created Secret %s/%s", namespace, secret_name)
+    except kubernetes.client.exceptions.ApiException as e:
+        if e.status == 409:
+            log.info("Secret %s/%s already exists, reading existing key", namespace, secret_name)
+            existing = core_v1.read_namespaced_secret(secret_name, namespace)
+            import base64
+
+            api_key = base64.b64decode(existing.data["api-key"]).decode()
+        else:
+            raise
+
+    # -- Service
+    svc_name = _resource_name(name, "svc")
+    svc_manifest = _build_service_manifest(name, namespace, owner_ref)
+    try:
+        core_v1.create_namespaced_service(namespace=namespace, body=svc_manifest)
+        log.info("Created Service %s/%s", namespace, svc_name)
+    except kubernetes.client.exceptions.ApiException as e:
+        if e.status == 409:
+            log.info("Service %s/%s already exists", namespace, svc_name)
+        else:
+            raise
+
+    # -- Pod
+    pod_name = _resource_name(name, "pod")
+    pod_manifest = _build_pod_manifest(
+        name, namespace, spec, api_key, owner_ref, pvc_name
+    )
+    try:
+        core_v1.create_namespaced_pod(namespace=namespace, body=pod_manifest)
+        log.info("Created Pod %s/%s", namespace, pod_name)
+    except kubernetes.client.exceptions.ApiException as e:
+        if e.status == 409:
+            log.info("Pod %s/%s already exists", namespace, pod_name)
+        else:
+            raise
+
+    # -- Update status
+    service_url = f"http://{svc_name}.{namespace}.svc:8000"
+    patch.status["podName"] = pod_name
+    patch.status["serviceName"] = svc_name
+    patch.status["serviceUrl"] = service_url
+    patch.status["apiKeySecret"] = secret_name
+    patch.status["phase"] = "Pending"
+    patch.status["conditions"] = _set_condition(
+        {"conditions": patch.status.get("conditions", [])},
+        "Ready",
+        "False",
+        "PodNotReady",
+        "Waiting for pod to become ready",
+    )
+
+
+@kopf.on.delete(API_GROUP, API_VERSION, RESOURCE_PLURAL)
+async def on_delete(name, namespace, **_):
+    """Log deletion — child resources are cleaned up via ownerReferences."""
+    log.info(
+        "Terminal %s/%s deleted. Child resources will be garbage-collected.", namespace, name
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pod watcher — update Terminal status when pod phase changes
+# ---------------------------------------------------------------------------
+
+
+@kopf.on.event("v1", "pods", labels={"app.kubernetes.io/managed-by": "terminals-controller"})
+async def on_pod_event(event, body, **_):
+    """Watch terminal pods and reflect readiness back into the Terminal CR status."""
+    pod = body
+    labels = pod.get("metadata", {}).get("labels", {})
+    terminal_name = labels.get("open-webui.com/terminal")
+    if not terminal_name:
+        return
+
+    namespace = pod["metadata"]["namespace"]
+    pod_phase = (pod.get("status") or {}).get("phase", "Unknown")
+
+    # Check container readiness
+    container_statuses = (pod.get("status") or {}).get("containerStatuses", [])
+    is_ready = any(cs.get("ready", False) for cs in container_statuses)
+
+    custom_api = kubernetes.client.CustomObjectsApi()
+    try:
+        terminal = custom_api.get_namespaced_custom_object(
+            group=API_GROUP,
+            version=API_VERSION,
+            namespace=namespace,
+            plural=RESOURCE_PLURAL,
+            name=terminal_name,
+        )
+    except kubernetes.client.exceptions.ApiException as e:
+        if e.status == 404:
+            return
+        raise
+
+    current_status = terminal.get("status", {})
+    current_phase = current_status.get("phase")
+
+    # Don't update if terminal is being torn down
+    if current_phase == "Terminating":
+        return
+
+    new_phase = current_phase
+    if is_ready and pod_phase == "Running":
+        new_phase = "Running"
+    elif pod_phase in ("Pending",):
+        new_phase = "Pending"
+    elif pod_phase in ("Failed", "Unknown"):
+        new_phase = "Pending"
+
+    if new_phase == current_phase and current_phase == "Running" and is_ready:
+        return  # No change needed
+
+    conditions = _set_condition(
+        current_status,
+        "Ready",
+        "True" if is_ready else "False",
+        "PodReady" if is_ready else "PodNotReady",
+        f"Pod phase: {pod_phase}",
+    )
+
+    status_patch = {
+        "status": {
+            "phase": new_phase,
+            "conditions": conditions,
+        }
+    }
+
+    if is_ready and new_phase == "Running":
+        status_patch["status"]["lastActivityAt"] = _now_iso()
+
+    try:
+        custom_api.patch_namespaced_custom_object_status(
+            group=API_GROUP,
+            version=API_VERSION,
+            namespace=namespace,
+            plural=RESOURCE_PLURAL,
+            name=terminal_name,
+            body=status_patch,
+        )
+    except kubernetes.client.exceptions.ApiException as e:
+        if e.status == 404:
+            return
+        log.warning("Failed to patch Terminal %s/%s status: %s", namespace, terminal_name, e)
+
+
+# ---------------------------------------------------------------------------
+# Idle timeout timer
+# ---------------------------------------------------------------------------
+
+
+@kopf.timer(API_GROUP, API_VERSION, RESOURCE_PLURAL, interval=60, idle=60)
+async def idle_check(spec, status, name, namespace, **_):
+    """Periodically check if a terminal has exceeded its idle timeout."""
+    phase = (status or {}).get("phase")
+    if phase not in ("Running", "Idle"):
+        return
+
+    last_activity = (status or {}).get("lastActivityAt")
+    if not last_activity:
+        return
+
+    timeout_minutes = spec.get("idleTimeoutMinutes", 30)
+    try:
+        last_dt = datetime.fromisoformat(last_activity.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return
+
+    elapsed = (datetime.now(timezone.utc) - last_dt).total_seconds() / 60
+
+    if elapsed < timeout_minutes:
+        return
+
+    log.info(
+        "Terminal %s/%s idle for %.1f min (timeout=%d). Deleting pod.",
+        namespace,
+        name,
+        elapsed,
+        timeout_minutes,
+    )
+
+    pod_name = (status or {}).get("podName")
+    if not pod_name:
+        return
+
+    # Delete the pod to free resources; the PVC and CRD remain
+    core_v1 = kubernetes.client.CoreV1Api()
+    try:
+        core_v1.delete_namespaced_pod(name=pod_name, namespace=namespace)
+    except kubernetes.client.exceptions.ApiException as e:
+        if e.status == 404:
+            log.info("Pod %s/%s already gone", namespace, pod_name)
+        else:
+            raise
+
+    # Update status to Idle
+    custom_api = kubernetes.client.CustomObjectsApi()
+    try:
+        custom_api.patch_namespaced_custom_object_status(
+            group=API_GROUP,
+            version=API_VERSION,
+            namespace=namespace,
+            plural=RESOURCE_PLURAL,
+            name=name,
+            body={
+                "status": {
+                    "phase": "Idle",
+                    "conditions": _set_condition(
+                        status,
+                        "Ready",
+                        "False",
+                        "IdleTimeout",
+                        f"Pod deleted after {elapsed:.0f} min of inactivity",
+                    ),
+                }
+            },
+        )
+    except kubernetes.client.exceptions.ApiException:
+        pass

--- a/kubernetes-controller/k8s.py
+++ b/kubernetes-controller/k8s.py
@@ -1,0 +1,228 @@
+"""Kubernetes helpers for managing Terminal CRDs.
+
+Handles CRUD operations on ``terminals.open-webui.com/v1alpha1`` custom resources
+and reading the API key from the associated Secret.
+"""
+
+import asyncio
+import base64
+import hashlib
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+import kubernetes
+from kubernetes import client as k8s
+
+from terminals.config import (
+    DEFAULT_CPU_LIMIT,
+    DEFAULT_CPU_REQUEST,
+    DEFAULT_IDLE_TIMEOUT_MINUTES,
+    DEFAULT_IMAGE,
+    DEFAULT_MEMORY_LIMIT,
+    DEFAULT_MEMORY_REQUEST,
+    DEFAULT_PERSISTENCE_ENABLED,
+    DEFAULT_PERSISTENCE_SIZE,
+    DEFAULT_STORAGE_CLASS,
+    TERMINAL_NAMESPACE,
+)
+
+log = logging.getLogger(__name__)
+
+API_GROUP = "open-webui.com"
+API_VERSION = "v1alpha1"
+RESOURCE_PLURAL = "terminals"
+
+
+def _terminal_name(user_id: str) -> str:
+    """Deterministic Terminal CR name from a user ID."""
+    short = hashlib.sha256(user_id.encode()).hexdigest()[:12]
+    return f"terminal-{short}"
+
+
+def _load_kube_config():
+    """Load in-cluster config, falling back to kubeconfig for local dev."""
+    try:
+        kubernetes.config.load_incluster_config()
+    except kubernetes.config.ConfigException:
+        kubernetes.config.load_kube_config()
+
+
+# Ensure config is loaded at import time.
+_load_kube_config()
+
+
+def get_terminal(user_id: str) -> Optional[dict]:
+    """Get the Terminal CR for a user, or None if it doesn't exist."""
+    custom_api = k8s.CustomObjectsApi()
+    name = _terminal_name(user_id)
+    try:
+        return custom_api.get_namespaced_custom_object(
+            group=API_GROUP,
+            version=API_VERSION,
+            namespace=TERMINAL_NAMESPACE,
+            plural=RESOURCE_PLURAL,
+            name=name,
+        )
+    except k8s.exceptions.ApiException as e:
+        if e.status == 404:
+            return None
+        raise
+
+
+def _list_running_terminals() -> list[dict]:
+    """List all Terminal CRs in Running phase."""
+    custom_api = k8s.CustomObjectsApi()
+    try:
+        result = custom_api.list_namespaced_custom_object(
+            group=API_GROUP,
+            version=API_VERSION,
+            namespace=TERMINAL_NAMESPACE,
+            plural=RESOURCE_PLURAL,
+        )
+        return [
+            t for t in result.get("items", [])
+            if (t.get("status") or {}).get("phase") == "Running"
+        ]
+    except k8s.exceptions.ApiException:
+        return []
+
+
+def create_terminal(user_id: str) -> dict:
+    """Create a Terminal CR for a user and return it."""
+    custom_api = k8s.CustomObjectsApi()
+    name = _terminal_name(user_id)
+
+    body = {
+        "apiVersion": f"{API_GROUP}/{API_VERSION}",
+        "kind": "Terminal",
+        "metadata": {
+            "name": name,
+            "namespace": TERMINAL_NAMESPACE,
+            "labels": {
+                "app.kubernetes.io/managed-by": "terminals-orchestrator",
+                "open-webui.com/user-id": user_id,
+            },
+        },
+        "spec": {
+            "userId": user_id,
+            "image": DEFAULT_IMAGE,
+            "resources": {
+                "requests": {
+                    "cpu": DEFAULT_CPU_REQUEST,
+                    "memory": DEFAULT_MEMORY_REQUEST,
+                },
+                "limits": {
+                    "cpu": DEFAULT_CPU_LIMIT,
+                    "memory": DEFAULT_MEMORY_LIMIT,
+                },
+            },
+            "idleTimeoutMinutes": DEFAULT_IDLE_TIMEOUT_MINUTES,
+            "packages": [],
+            "pipPackages": [],
+            "persistence": {
+                "enabled": DEFAULT_PERSISTENCE_ENABLED,
+                "size": DEFAULT_PERSISTENCE_SIZE,
+                "storageClass": DEFAULT_STORAGE_CLASS,
+            },
+        },
+    }
+
+    try:
+        return custom_api.create_namespaced_custom_object(
+            group=API_GROUP,
+            version=API_VERSION,
+            namespace=TERMINAL_NAMESPACE,
+            plural=RESOURCE_PLURAL,
+            body=body,
+        )
+    except k8s.exceptions.ApiException as e:
+        if e.status == 409:
+            # Already exists — return existing
+            return get_terminal(user_id)  # type: ignore[return-value]
+        raise
+
+
+def delete_terminal(user_id: str) -> bool:
+    """Delete the Terminal CR for a user. Returns True if deleted, False if not found."""
+    custom_api = k8s.CustomObjectsApi()
+    name = _terminal_name(user_id)
+    try:
+        custom_api.delete_namespaced_custom_object(
+            group=API_GROUP,
+            version=API_VERSION,
+            namespace=TERMINAL_NAMESPACE,
+            plural=RESOURCE_PLURAL,
+            name=name,
+        )
+        return True
+    except k8s.exceptions.ApiException as e:
+        if e.status == 404:
+            return False
+        raise
+
+
+def touch_activity(user_id: str) -> None:
+    """Update lastActivityAt on the Terminal CR to prevent idle culling."""
+    custom_api = k8s.CustomObjectsApi()
+    name = _terminal_name(user_id)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    try:
+        custom_api.patch_namespaced_custom_object_status(
+            group=API_GROUP,
+            version=API_VERSION,
+            namespace=TERMINAL_NAMESPACE,
+            plural=RESOURCE_PLURAL,
+            name=name,
+            body={"status": {"lastActivityAt": now}},
+        )
+    except k8s.exceptions.ApiException as e:
+        if e.status != 404:
+            log.warning("Failed to touch activity for %s: %s", name, e)
+
+
+def get_api_key(secret_name: str) -> Optional[str]:
+    """Read the API key from a Kubernetes Secret."""
+    core_v1 = k8s.CoreV1Api()
+    try:
+        secret = core_v1.read_namespaced_secret(secret_name, TERMINAL_NAMESPACE)
+        raw = secret.data.get("api-key", "")
+        return base64.b64decode(raw).decode() if raw else None
+    except k8s.exceptions.ApiException as e:
+        if e.status == 404:
+            return None
+        raise
+
+
+def ensure_terminal(user_id: str) -> dict:
+    """Get or create a Terminal CR. If the terminal was idled, re-create the pod.
+
+    Returns the Terminal CR dict (may still be in Pending/Provisioning phase).
+    """
+    terminal = get_terminal(user_id)
+    if terminal is None:
+        return create_terminal(user_id)
+
+    phase = (terminal.get("status") or {}).get("phase")
+    if phase == "Idle":
+        # Terminal was idled — delete and re-create to spawn a fresh pod
+        delete_terminal(user_id)
+        return create_terminal(user_id)
+
+    return terminal
+
+
+async def wait_for_ready(user_id: str, timeout: float) -> Optional[dict]:
+    """Poll until the Terminal CR reaches Running phase or timeout expires.
+
+    Returns the Terminal CR dict if ready, or None on timeout.
+    """
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        terminal = get_terminal(user_id)
+        if terminal:
+            phase = (terminal.get("status") or {}).get("phase")
+            if phase == "Running":
+                return terminal
+        await asyncio.sleep(1.0)
+    return None

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -1,0 +1,148 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: terminals.open-webui.com
+  labels:
+    app.kubernetes.io/part-of: open-webui-terminals
+spec:
+  group: open-webui.com
+  names:
+    kind: Terminal
+    listKind: TerminalList
+    plural: terminals
+    singular: terminal
+    shortNames:
+      - term
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          required:
+            - spec
+          properties:
+            spec:
+              type: object
+              required:
+                - userId
+              properties:
+                userId:
+                  type: string
+                  description: Open WebUI user ID that owns this terminal.
+                image:
+                  type: string
+                  default: "ghcr.io/open-webui/open-terminal:latest"
+                  description: Container image for the Open Terminal instance.
+                resources:
+                  type: object
+                  properties:
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          default: "100m"
+                        memory:
+                          type: string
+                          default: "256Mi"
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          default: "1"
+                        memory:
+                          type: string
+                          default: "1Gi"
+                idleTimeoutMinutes:
+                  type: integer
+                  default: 30
+                  minimum: 1
+                  description: >-
+                    Minutes of inactivity before the terminal pod is stopped.
+                packages:
+                  type: array
+                  items:
+                    type: string
+                  default: []
+                  description: Apt packages to pre-install in the terminal.
+                pipPackages:
+                  type: array
+                  items:
+                    type: string
+                  default: []
+                  description: Pip packages to pre-install in the terminal.
+                persistence:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                      default: true
+                    size:
+                      type: string
+                      default: "1Gi"
+                    storageClass:
+                      type: string
+                      default: ""
+            status:
+              type: object
+              properties:
+                phase:
+                  type: string
+                  enum:
+                    - Pending
+                    - Provisioning
+                    - Running
+                    - Idle
+                    - Terminating
+                podName:
+                  type: string
+                serviceName:
+                  type: string
+                serviceUrl:
+                  type: string
+                apiKeySecret:
+                  type: string
+                  description: Name of the Secret holding the terminal API key.
+                lastActivityAt:
+                  type: string
+                  format: date-time
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      reason:
+                        type: string
+                      message:
+                        type: string
+      subresources:
+        status: {}
+      additionalPrinterColumns:
+        - name: User
+          type: string
+          jsonPath: .spec.userId
+        - name: Phase
+          type: string
+          jsonPath: .status.phase
+        - name: Service URL
+          type: string
+          jsonPath: .status.serviceUrl
+          priority: 1
+        - name: Last Activity
+          type: date
+          jsonPath: .status.lastActivityAt
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp

--- a/manifests/rbac.yaml
+++ b/manifests/rbac.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: terminals-controller
+  namespace: open-webui
+  labels:
+    app.kubernetes.io/name: terminals-controller
+    app.kubernetes.io/part-of: open-webui-terminals
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: terminals-controller
+  labels:
+    app.kubernetes.io/name: terminals-controller
+    app.kubernetes.io/part-of: open-webui-terminals
+rules:
+  # Terminal CRDs — full control
+  - apiGroups: ["open-webui.com"]
+    resources: ["terminals", "terminals/status"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Pods — create and manage terminal pods
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Services — create ClusterIP services for terminal pods
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Secrets — store per-terminal API keys
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # PVCs — optional persistent storage per terminal
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Events — kopf posts events on handled objects
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  # Leases — kopf leader election
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # CRD discovery — kopf needs to list/watch CRDs to discover watched resources
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: terminals-controller
+  labels:
+    app.kubernetes.io/name: terminals-controller
+    app.kubernetes.io/part-of: open-webui-terminals
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: terminals-controller
+subjects:
+  - kind: ServiceAccount
+    name: terminals-controller
+    namespace: open-webui

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "open-webui-terminals"
+version = "0.1.0"
+description = "Multi-tenant terminal orchestrator for Open Terminal on Kubernetes"
+readme = "README.md"
+license = "LicenseRef-Proprietary"
+requires-python = ">=3.11"
+dependencies = [
+    "kubernetes>=31.0.0",
+]
+
+[project.optional-dependencies]
+controller = [
+    "kopf>=1.37",
+]
+orchestrator = [
+    "fastapi>=0.115.0",
+    "uvicorn>=0.30.0",
+    "aiohttp>=3.10.0",
+]
+dev = [
+    "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["terminals"]
+
+[project.scripts]
+terminals-orchestrator = "terminals.app:main"


### PR DESCRIPTION
## Description
Enables per-user terminal provisioning via Kubernetes Controller. Adds a Kubernetes Operator that automatically provisions isolated Open Terminal pods for each Open WebUI user on demand.

### Features
- Terminal CRD (terminals.open-webui.com/v1alpha1) — declares per-user terminal instances as native Kubernetes resources
- kopf Controller — reconciles Pod, Service, Secret, and PVC for each Terminal CR; automatic idle culling after configurable timeout
- FastAPI Orchestrator — single authenticated entry point that handles on-demand provisioning, readiness waiting, and HTTP/WebSocket proxying to per-user pods
- OpenAPI spec passthrough — cached /openapi.json endpoint so Open WebUI discovers terminal tools without per-user auth
- Helm sub-chart — optional dependency wired into the Open WebUI parent chart, toggle with terminals.enabled: true
- Full RBAC & CRD manifests — ready-to-apply manifests for manual deployment
- Configurable resources, persistence, and idle timeout via environment variables

## Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](./CLA.md), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
