### PR TITLE
Make Kubernetes operator backend production-ready

### DIFF
--- a/manifests/terminal-crd.yaml
+++ b/manifests/terminal-crd.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: terminals.openwebui.com
+  labels:
+    app.kubernetes.io/part-of: open-terminal
 spec:
   group: openwebui.com
   scope: Namespaced
@@ -9,6 +11,7 @@ spec:
     plural: terminals
     singular: terminal
     kind: Terminal
+    listKind: TerminalList
     shortNames:
       - term
   versions:
@@ -18,64 +21,117 @@ spec:
       schema:
         openAPIV3Schema:
           type: object
+          required:
+            - spec
           properties:
             spec:
               type: object
               required:
                 - userId
-                - apiKey
               properties:
                 userId:
                   type: string
-                  description: Open WebUI user ID.
+                  description: Open WebUI user ID that owns this terminal.
                 image:
                   type: string
                   default: "ghcr.io/open-webui/open-terminal:latest"
-                  description: Container image for the terminal.
-                apiKey:
-                  type: string
-                  description: API key for the terminal instance.
-                replicas:
+                  description: Container image for the Open Terminal instance.
+                resources:
+                  type: object
+                  properties:
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          default: "100m"
+                        memory:
+                          type: string
+                          default: "256Mi"
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                          default: "1"
+                        memory:
+                          type: string
+                          default: "1Gi"
+                idleTimeoutMinutes:
                   type: integer
-                  minimum: 0
-                  maximum: 1
-                  default: 1
-                  description: Set to 0 to stop, 1 to run.
-                storage:
+                  default: 30
+                  minimum: 1
+                  description: >-
+                    Minutes of inactivity before the terminal pod is stopped.
+                packages:
+                  type: array
+                  items:
+                    type: string
+                  default: []
+                  description: Apt packages to pre-install in the terminal.
+                pipPackages:
+                  type: array
+                  items:
+                    type: string
+                  default: []
+                  description: Pip packages to pre-install in the terminal.
+                persistence:
                   type: object
                   properties:
                     enabled:
                       type: boolean
-                      default: false
+                      default: true
                     size:
                       type: string
                       default: "1Gi"
                     storageClass:
                       type: string
-                      nullable: true
+                      default: ""
             status:
               type: object
               properties:
                 phase:
                   type: string
                   enum:
+                    - Pending
                     - Provisioning
                     - Running
-                    - Stopped
+                    - Idle
                     - Error
                 podName:
                   type: string
                 serviceName:
                   type: string
-                host:
+                serviceUrl:
                   type: string
-                  description: Service FQDN reachable within the cluster.
-                port:
-                  type: integer
-                  default: 8000
+                  description: Full URL (http://svc:port) reachable within the cluster.
+                apiKeySecret:
+                  type: string
+                  description: Name of the Secret holding the terminal API key.
+                lastActivityAt:
+                  type: string
+                  format: date-time
+                  description: Timestamp of the last proxied request.
                 message:
                   type: string
                   description: Human-readable status message.
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      status:
+                        type: string
+                        enum: ["True", "False", "Unknown"]
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      reason:
+                        type: string
+                      message:
+                        type: string
       subresources:
         status: {}
       additionalPrinterColumns:
@@ -85,9 +141,13 @@ spec:
         - name: Phase
           type: string
           jsonPath: .status.phase
-        - name: Host
+        - name: Service URL
           type: string
-          jsonPath: .status.host
+          jsonPath: .status.serviceUrl
+          priority: 1
+        - name: Last Activity
+          type: date
+          jsonPath: .status.lastActivityAt
         - name: Age
           type: date
           jsonPath: .metadata.creationTimestamp

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -4,8 +4,10 @@ WORKDIR /app
 
 RUN pip install --no-cache-dir \
     kopf>=1.37.0 \
-    kubernetes-asyncio>=31.0.0
+    kubernetes>=31.0.0
 
 COPY handler.py /app/handler.py
+
+USER 65534:65534
 
 ENTRYPOINT ["kopf", "run", "/app/handler.py", "--verbose"]

--- a/operator/handler.py
+++ b/operator/handler.py
@@ -3,16 +3,28 @@
 Watches ``Terminal`` custom resources (``terminals.openwebui.com/v1alpha1``)
 and reconciles the underlying Kubernetes resources:
 
+- **Secret** holding a generated API key
 - **Pod** running the open-terminal container
 - **Service** (ClusterIP) exposing port 8000
-- **PVC** (optional) for persistent ``/home/user`` storage
+- **PVC** (optional) for persistent ``/workspace`` storage
 
 The orchestrator creates/deletes Terminal CRs; this operator does the rest.
+
+Ported from the ``kubernetes-controller`` branch with the ABC-compatible
+``openwebui.com`` API group retained for extensibility.
 """
 
+import base64
+import logging
+import secrets
+import string
+from datetime import datetime, timezone
+
 import kopf
-import kubernetes_asyncio as k8s
-from kubernetes_asyncio import client, config
+import kubernetes
+from kubernetes import client as k8s
+
+log = logging.getLogger(__name__)
 
 GROUP = "openwebui.com"
 VERSION = "v1alpha1"
@@ -25,13 +37,14 @@ PLURAL = "terminals"
 
 
 @kopf.on.startup()
-async def configure(settings: kopf.OperatorSettings, **_):
-    """Load K8s config at startup."""
+def configure(settings: kopf.OperatorSettings, **_):
+    """Load K8s config and configure kopf settings."""
     try:
-        config.load_incluster_config()
-    except config.ConfigException:
-        await config.load_kube_config()
-    settings.posting.level = kopf.INFO
+        kubernetes.config.load_incluster_config()
+    except kubernetes.config.ConfigException:
+        kubernetes.config.load_kube_config()
+    settings.posting.level = logging.WARNING
+    settings.persistence.finalizer = "terminals.openwebui.com/finalizer"
 
 
 # ---------------------------------------------------------------------------
@@ -39,40 +52,221 @@ async def configure(settings: kopf.OperatorSettings, **_):
 # ---------------------------------------------------------------------------
 
 
-def _owner_ref(body: dict) -> list[dict]:
-    """Build an ownerReferences list so child resources are garbage-collected."""
-    return [
-        {
-            "apiVersion": f"{GROUP}/{VERSION}",
-            "kind": "Terminal",
-            "name": body["metadata"]["name"],
-            "uid": body["metadata"]["uid"],
-            "controller": True,
-            "blockOwnerDeletion": True,
-        }
-    ]
+def _generate_api_key(length: int = 48) -> str:
+    alphabet = string.ascii_letters + string.digits
+    return "sk-" + "".join(secrets.choice(alphabet) for _ in range(length))
 
 
-def _labels(spec: dict) -> dict[str, str]:
+def _resource_name(name: str, suffix: str) -> str:
+    """Derive child resource names from the Terminal CR name."""
+    return f"{name}-{suffix}"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _owner_ref(body: dict) -> dict:
+    """Build a single ownerReference dict for garbage collection."""
     return {
-        "app.kubernetes.io/managed-by": "open-terminal-operator",
-        "app.kubernetes.io/part-of": "open-terminal",
-        "openwebui.com/user-id": spec["userId"],
+        "apiVersion": f"{GROUP}/{VERSION}",
+        "kind": "Terminal",
+        "name": body["metadata"]["name"],
+        "uid": body["metadata"]["uid"],
+        "controller": True,
+        "blockOwnerDeletion": True,
     }
 
 
-async def _patch_status(name: str, namespace: str, status: dict):
-    """Patch the Terminal CR status subresource."""
-    async with k8s.client.ApiClient() as api:
-        custom = client.CustomObjectsApi(api)
-        await custom.patch_namespaced_custom_object_status(
-            group=GROUP,
-            version=VERSION,
-            namespace=namespace,
-            plural=PLURAL,
-            name=name,
-            body={"status": status},
+def _labels(name: str) -> dict[str, str]:
+    return {
+        "app.kubernetes.io/name": "open-terminal",
+        "app.kubernetes.io/instance": name,
+        "app.kubernetes.io/managed-by": "open-terminal-operator",
+        "openwebui.com/terminal": name,
+    }
+
+
+def _set_condition(
+    status: dict,
+    cond_type: str,
+    cond_status: str,
+    reason: str = "",
+    message: str = "",
+) -> list:
+    """Create or update a condition in the conditions list."""
+    conditions = list(status.get("conditions") or [])
+    for c in conditions:
+        if c["type"] == cond_type:
+            c["status"] = cond_status
+            c["lastTransitionTime"] = _now_iso()
+            c["reason"] = reason
+            c["message"] = message
+            return conditions
+    conditions.append(
+        {
+            "type": cond_type,
+            "status": cond_status,
+            "lastTransitionTime": _now_iso(),
+            "reason": reason,
+            "message": message,
+        }
+    )
+    return conditions
+
+
+# ---------------------------------------------------------------------------
+# Manifest builders
+# ---------------------------------------------------------------------------
+
+
+def _build_pod_manifest(
+    name: str,
+    namespace: str,
+    spec: dict,
+    api_key: str,
+    owner_ref: dict,
+    pvc_name: str | None,
+) -> dict:
+    """Build the Pod manifest for an Open Terminal instance."""
+    image = spec.get("image", "ghcr.io/open-webui/open-terminal:latest")
+    resources_spec = spec.get("resources", {})
+    packages = spec.get("packages", [])
+    pip_packages = spec.get("pipPackages", [])
+
+    env = [
+        {"name": "OPEN_TERMINAL_API_KEY", "value": api_key},
+        {"name": "OPEN_TERMINAL_HOST", "value": "0.0.0.0"},
+        {"name": "OPEN_TERMINAL_PORT", "value": "8000"},
+    ]
+    if packages:
+        env.append({"name": "OPEN_TERMINAL_PACKAGES", "value": " ".join(packages)})
+    if pip_packages:
+        env.append({"name": "OPEN_TERMINAL_PIP_PACKAGES", "value": " ".join(pip_packages)})
+
+    volume_mounts = []
+    volumes = []
+    if pvc_name:
+        volume_mounts.append({"name": "workspace", "mountPath": "/workspace"})
+        volumes.append(
+            {"name": "workspace", "persistentVolumeClaim": {"claimName": pvc_name}}
         )
+
+    container = {
+        "name": "open-terminal",
+        "image": image,
+        "ports": [{"containerPort": 8000, "name": "http", "protocol": "TCP"}],
+        "env": env,
+        "volumeMounts": volume_mounts,
+        "readinessProbe": {
+            "httpGet": {"path": "/health", "port": 8000},
+            "initialDelaySeconds": 3,
+            "periodSeconds": 5,
+        },
+        "livenessProbe": {
+            "httpGet": {"path": "/health", "port": 8000},
+            "initialDelaySeconds": 10,
+            "periodSeconds": 15,
+        },
+    }
+
+    requests = resources_spec.get("requests", {})
+    limits = resources_spec.get("limits", {})
+    if requests or limits:
+        container["resources"] = {}
+        if requests:
+            container["resources"]["requests"] = requests
+        if limits:
+            container["resources"]["limits"] = limits
+
+    pod_labels = _labels(name)
+
+    return {
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": _resource_name(name, "pod"),
+            "namespace": namespace,
+            "labels": pod_labels,
+            "ownerReferences": [owner_ref],
+        },
+        "spec": {
+            "containers": [container],
+            "volumes": volumes,
+            "restartPolicy": "Always",
+            "enableServiceLinks": False,
+            "automountServiceAccountToken": False,
+        },
+    }
+
+
+def _build_service_manifest(
+    name: str, namespace: str, owner_ref: dict
+) -> dict:
+    return {
+        "apiVersion": "v1",
+        "kind": "Service",
+        "metadata": {
+            "name": _resource_name(name, "svc"),
+            "namespace": namespace,
+            "labels": _labels(name),
+            "ownerReferences": [owner_ref],
+        },
+        "spec": {
+            "type": "ClusterIP",
+            "selector": {"openwebui.com/terminal": name},
+            "ports": [
+                {"name": "http", "port": 8000, "targetPort": 8000, "protocol": "TCP"}
+            ],
+        },
+    }
+
+
+def _build_secret_manifest(
+    name: str, namespace: str, api_key: str, owner_ref: dict
+) -> dict:
+    return {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {
+            "name": _resource_name(name, "apikey"),
+            "namespace": namespace,
+            "labels": _labels(name),
+            "ownerReferences": [owner_ref],
+        },
+        "type": "Opaque",
+        "data": {
+            "api-key": base64.b64encode(api_key.encode()).decode(),
+        },
+    }
+
+
+def _build_pvc_manifest(
+    name: str, namespace: str, spec: dict, owner_ref: dict
+) -> dict:
+    persistence = spec.get("persistence", {})
+    size = persistence.get("size", "1Gi")
+    storage_class = persistence.get("storageClass", "")
+
+    # NOTE: PVCs intentionally have NO ownerReference so they survive
+    # Terminal CR deletion.  User workspace data must persist across
+    # idle-reap / re-provision cycles.
+    pvc = {
+        "apiVersion": "v1",
+        "kind": "PersistentVolumeClaim",
+        "metadata": {
+            "name": _resource_name(name, "pvc"),
+            "namespace": namespace,
+            "labels": _labels(name),
+        },
+        "spec": {
+            "accessModes": ["ReadWriteOnce"],
+            "resources": {"requests": {"storage": size}},
+        },
+    }
+    if storage_class:
+        pvc["spec"]["storageClassName"] = storage_class
+    return pvc
 
 
 # ---------------------------------------------------------------------------
@@ -81,226 +275,92 @@ async def _patch_status(name: str, namespace: str, status: dict):
 
 
 @kopf.on.create(GROUP, VERSION, PLURAL)
-async def on_create(spec, name, namespace, body, **_):
-    """Provision a Pod + Service (+ optional PVC) for a new Terminal CR."""
-    labels = _labels(spec)
-    owner = _owner_ref(body)
-    image = spec.get("image", "ghcr.io/open-webui/open-terminal:latest")
-    api_key = spec["apiKey"]
-    storage = spec.get("storage", {})
+async def on_create(body, spec, name, namespace, patch, **_):
+    """Create all child resources for a new Terminal CR."""
+    log.info("Creating terminal %s/%s for user %s", namespace, name, spec.get("userId"))
 
-    await _patch_status(name, namespace, {"phase": "Provisioning"})
+    owner_ref = _owner_ref(body)
+    api_key = _generate_api_key()
+    core_v1 = k8s.CoreV1Api()
 
-    async with k8s.client.ApiClient() as api:
-        core = client.CoreV1Api(api)
-
-        # ---- PVC (optional) ----------------------------------------------
-        volumes = []
-        volume_mounts = []
-
-        if storage.get("enabled"):
-            pvc = client.V1PersistentVolumeClaim(
-                metadata=client.V1ObjectMeta(
-                    name=name,
-                    namespace=namespace,
-                    labels=labels,
-                    owner_references=owner,
-                ),
-                spec=client.V1PersistentVolumeClaimSpec(
-                    access_modes=["ReadWriteOnce"],
-                    resources=client.V1VolumeResourceRequirements(
-                        requests={"storage": storage.get("size", "1Gi")},
-                    ),
-                    **(
-                        {"storage_class_name": storage["storageClass"]}
-                        if storage.get("storageClass")
-                        else {}
-                    ),
-                ),
-            )
-            try:
-                await core.create_namespaced_persistent_volume_claim(namespace, pvc)
-            except client.exceptions.ApiException as exc:
-                if exc.status != 409:
-                    raise
-
-            volumes.append(
-                client.V1Volume(
-                    name="home",
-                    persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource(
-                        claim_name=name,
-                    ),
-                )
-            )
-            volume_mounts.append(
-                client.V1VolumeMount(name="home", mount_path="/home/user"),
-            )
-
-        # ---- Pod ---------------------------------------------------------
-        pod = client.V1Pod(
-            metadata=client.V1ObjectMeta(
-                name=name,
-                namespace=namespace,
-                labels=labels,
-                owner_references=owner,
-            ),
-            spec=client.V1PodSpec(
-                containers=[
-                    client.V1Container(
-                        name="open-terminal",
-                        image=image,
-                        ports=[client.V1ContainerPort(container_port=8000)],
-                        env=[
-                            client.V1EnvVar(
-                                name="OPEN_TERMINAL_API_KEY", value=api_key
-                            ),
-                        ],
-                        volume_mounts=volume_mounts or None,
-                        readiness_probe=client.V1Probe(
-                            http_get=client.V1HTTPGetAction(
-                                path="/health", port=8000
-                            ),
-                            initial_delay_seconds=3,
-                            period_seconds=5,
-                        ),
-                    )
-                ],
-                volumes=volumes or None,
-                restart_policy="Always",
-            ),
-        )
-        try:
-            await core.create_namespaced_pod(namespace, pod)
-        except client.exceptions.ApiException as exc:
-            if exc.status != 409:
-                await _patch_status(
-                    name, namespace, {"phase": "Error", "message": str(exc)}
-                )
-                raise
-
-        # ---- Service -----------------------------------------------------
-        svc = client.V1Service(
-            metadata=client.V1ObjectMeta(
-                name=name,
-                namespace=namespace,
-                labels=labels,
-                owner_references=owner,
-            ),
-            spec=client.V1ServiceSpec(
-                type="ClusterIP",
-                selector={"openwebui.com/user-id": spec["userId"]},
-                ports=[client.V1ServicePort(port=8000, target_port=8000)],
-            ),
-        )
-        try:
-            await core.create_namespaced_service(namespace, svc)
-        except client.exceptions.ApiException as exc:
-            if exc.status != 409:
-                raise
-
-    host = f"{name}.{namespace}.svc.cluster.local"
-    await _patch_status(
-        name,
-        namespace,
-        {
-            "phase": "Running",
-            "podName": name,
-            "serviceName": name,
-            "host": host,
-            "port": 8000,
-        },
+    # -- Status: Provisioning
+    patch.status["phase"] = "Provisioning"
+    patch.status["lastActivityAt"] = _now_iso()
+    patch.status["conditions"] = _set_condition(
+        {}, "Ready", "False", "Provisioning", "Creating child resources"
     )
 
-    return {"message": f"Terminal {name} provisioned at {host}:8000"}
+    # -- PVC (if persistence enabled)
+    persistence = spec.get("persistence", {})
+    pvc_name = None
+    if persistence.get("enabled", True):
+        pvc_name = _resource_name(name, "pvc")
+        pvc_manifest = _build_pvc_manifest(name, namespace, spec, owner_ref)
+        try:
+            core_v1.create_namespaced_persistent_volume_claim(
+                namespace=namespace, body=pvc_manifest
+            )
+            log.info("Created PVC %s/%s", namespace, pvc_name)
+        except k8s.exceptions.ApiException as e:
+            if e.status == 409:
+                log.info("PVC %s/%s already exists", namespace, pvc_name)
+            else:
+                raise
 
+    # -- Secret (API key)
+    secret_name = _resource_name(name, "apikey")
+    secret_manifest = _build_secret_manifest(name, namespace, api_key, owner_ref)
+    try:
+        core_v1.create_namespaced_secret(namespace=namespace, body=secret_manifest)
+        log.info("Created Secret %s/%s", namespace, secret_name)
+    except k8s.exceptions.ApiException as e:
+        if e.status == 409:
+            log.info("Secret %s/%s already exists, reading existing key", namespace, secret_name)
+            existing = core_v1.read_namespaced_secret(secret_name, namespace)
+            api_key = base64.b64decode(existing.data["api-key"]).decode()
+        else:
+            raise
 
-# ---------------------------------------------------------------------------
-# Replicas field change (start / stop)
-# ---------------------------------------------------------------------------
+    # -- Service
+    svc_name = _resource_name(name, "svc")
+    svc_manifest = _build_service_manifest(name, namespace, owner_ref)
+    try:
+        core_v1.create_namespaced_service(namespace=namespace, body=svc_manifest)
+        log.info("Created Service %s/%s", namespace, svc_name)
+    except k8s.exceptions.ApiException as e:
+        if e.status == 409:
+            log.info("Service %s/%s already exists", namespace, svc_name)
+        else:
+            raise
 
+    # -- Pod
+    pod_name = _resource_name(name, "pod")
+    pod_manifest = _build_pod_manifest(
+        name, namespace, spec, api_key, owner_ref, pvc_name
+    )
+    try:
+        core_v1.create_namespaced_pod(namespace=namespace, body=pod_manifest)
+        log.info("Created Pod %s/%s", namespace, pod_name)
+    except k8s.exceptions.ApiException as e:
+        if e.status == 409:
+            log.info("Pod %s/%s already exists", namespace, pod_name)
+        else:
+            raise
 
-@kopf.on.field(GROUP, VERSION, PLURAL, field="spec.replicas")
-async def on_replicas_change(spec, name, namespace, old, new, **_):
-    """Handle spec.replicas changes for start/stop."""
-    replicas = new or spec.get("replicas", 1)
-
-    async with k8s.client.ApiClient() as api:
-        core = client.CoreV1Api(api)
-
-        if replicas == 0:
-            # Stop — delete the Pod (Service stays for quick restart).
-            try:
-                await core.delete_namespaced_pod(name, namespace)
-            except client.exceptions.ApiException:
-                pass
-            await _patch_status(name, namespace, {"phase": "Stopped"})
-
-        elif replicas == 1:
-            # Start — need to check if Pod exists, recreate if not.
-            try:
-                await core.read_namespaced_pod(name, namespace)
-                # Pod exists, nothing to do.
-                await _patch_status(name, namespace, {"phase": "Running"})
-            except client.exceptions.ApiException:
-                # Pod is gone — trigger a full re-provision by raising a
-                # temporary error so Kopf retries via the create handler.
-                # For simplicity, we recreate inline.
-                labels = _labels(spec)
-                image = spec.get("image", "ghcr.io/open-webui/open-terminal:latest")
-                api_key = spec["apiKey"]
-                storage = spec.get("storage", {})
-
-                volumes = []
-                volume_mounts = []
-                if storage.get("enabled"):
-                    volumes.append(
-                        client.V1Volume(
-                            name="home",
-                            persistent_volume_claim=client.V1PersistentVolumeClaimVolumeSource(
-                                claim_name=name,
-                            ),
-                        )
-                    )
-                    volume_mounts.append(
-                        client.V1VolumeMount(name="home", mount_path="/home/user"),
-                    )
-
-                pod = client.V1Pod(
-                    metadata=client.V1ObjectMeta(
-                        name=name,
-                        namespace=namespace,
-                        labels=labels,
-                    ),
-                    spec=client.V1PodSpec(
-                        containers=[
-                            client.V1Container(
-                                name="open-terminal",
-                                image=image,
-                                ports=[
-                                    client.V1ContainerPort(container_port=8000)
-                                ],
-                                env=[
-                                    client.V1EnvVar(
-                                        name="OPEN_TERMINAL_API_KEY",
-                                        value=api_key,
-                                    ),
-                                ],
-                                volume_mounts=volume_mounts or None,
-                                readiness_probe=client.V1Probe(
-                                    http_get=client.V1HTTPGetAction(
-                                        path="/health", port=8000
-                                    ),
-                                    initial_delay_seconds=3,
-                                    period_seconds=5,
-                                ),
-                            )
-                        ],
-                        volumes=volumes or None,
-                        restart_policy="Always",
-                    ),
-                )
-                await core.create_namespaced_pod(namespace, pod)
-                await _patch_status(name, namespace, {"phase": "Running"})
+    # -- Update status
+    service_url = f"http://{svc_name}.{namespace}.svc:8000"
+    patch.status["podName"] = pod_name
+    patch.status["serviceName"] = svc_name
+    patch.status["serviceUrl"] = service_url
+    patch.status["apiKeySecret"] = secret_name
+    patch.status["phase"] = "Pending"
+    patch.status["conditions"] = _set_condition(
+        {"conditions": patch.status.get("conditions", [])},
+        "Ready",
+        "False",
+        "PodNotReady",
+        "Waiting for pod to become ready",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -310,9 +370,170 @@ async def on_replicas_change(spec, name, namespace, old, new, **_):
 
 @kopf.on.delete(GROUP, VERSION, PLURAL)
 async def on_delete(name, namespace, **_):
-    """Log deletion — K8s garbage-collects child resources via ownerReferences."""
-    kopf.info(
-        {"metadata": {"name": name, "namespace": namespace}},
-        reason="Deleted",
-        message=f"Terminal {name} deleted, child resources will be garbage-collected.",
+    """Log deletion — child resources are cleaned up via ownerReferences."""
+    log.info(
+        "Terminal %s/%s deleted. Child resources will be garbage-collected.",
+        namespace,
+        name,
     )
+
+
+# ---------------------------------------------------------------------------
+# Pod watcher — update Terminal status when pod phase changes
+# ---------------------------------------------------------------------------
+
+
+@kopf.on.event("v1", "pods", labels={"app.kubernetes.io/managed-by": "open-terminal-operator"})
+async def on_pod_event(event, body, **_):
+    """Watch terminal pods and reflect readiness back into the Terminal CR status."""
+    pod = body
+    labels = pod.get("metadata", {}).get("labels", {})
+    terminal_name = labels.get("openwebui.com/terminal")
+    if not terminal_name:
+        return
+
+    namespace = pod["metadata"]["namespace"]
+    pod_phase = (pod.get("status") or {}).get("phase", "Unknown")
+
+    # Check container readiness
+    container_statuses = (pod.get("status") or {}).get("containerStatuses", [])
+    is_ready = any(cs.get("ready", False) for cs in container_statuses)
+
+    custom_api = k8s.CustomObjectsApi()
+    try:
+        terminal = custom_api.get_namespaced_custom_object(
+            group=GROUP,
+            version=VERSION,
+            namespace=namespace,
+            plural=PLURAL,
+            name=terminal_name,
+        )
+    except k8s.exceptions.ApiException as e:
+        if e.status == 404:
+            return
+        raise
+
+    current_status = terminal.get("status", {})
+    current_phase = current_status.get("phase")
+
+    # Don't update if terminal is being torn down
+    if current_phase in ("Idle",):
+        return
+
+    new_phase = current_phase
+    if is_ready and pod_phase == "Running":
+        new_phase = "Running"
+    elif pod_phase in ("Pending",):
+        new_phase = "Pending"
+    elif pod_phase in ("Failed", "Unknown"):
+        new_phase = "Error"
+
+    if new_phase == current_phase and current_phase == "Running" and is_ready:
+        return  # No change needed
+
+    conditions = _set_condition(
+        current_status,
+        "Ready",
+        "True" if is_ready else "False",
+        "PodReady" if is_ready else "PodNotReady",
+        f"Pod phase: {pod_phase}",
+    )
+
+    status_patch = {
+        "status": {
+            "phase": new_phase,
+            "conditions": conditions,
+        }
+    }
+
+    if is_ready and new_phase == "Running":
+        status_patch["status"]["lastActivityAt"] = _now_iso()
+
+    try:
+        custom_api.patch_namespaced_custom_object_status(
+            group=GROUP,
+            version=VERSION,
+            namespace=namespace,
+            plural=PLURAL,
+            name=terminal_name,
+            body=status_patch,
+        )
+    except k8s.exceptions.ApiException as e:
+        if e.status == 404:
+            return
+        log.warning("Failed to patch Terminal %s/%s status: %s", namespace, terminal_name, e)
+
+
+# ---------------------------------------------------------------------------
+# Idle timeout timer
+# ---------------------------------------------------------------------------
+
+
+@kopf.timer(GROUP, VERSION, PLURAL, interval=60, idle=60)
+async def idle_check(spec, status, name, namespace, **_):
+    """Periodically check if a terminal has exceeded its idle timeout."""
+    phase = (status or {}).get("phase")
+    if phase not in ("Running", "Idle"):
+        return
+
+    last_activity = (status or {}).get("lastActivityAt")
+    if not last_activity:
+        return
+
+    timeout_minutes = spec.get("idleTimeoutMinutes", 30)
+    try:
+        last_dt = datetime.fromisoformat(last_activity.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return
+
+    elapsed = (datetime.now(timezone.utc) - last_dt).total_seconds() / 60
+
+    if elapsed < timeout_minutes:
+        return
+
+    log.info(
+        "Terminal %s/%s idle for %.1f min (timeout=%d). Deleting pod.",
+        namespace,
+        name,
+        elapsed,
+        timeout_minutes,
+    )
+
+    pod_name = (status or {}).get("podName")
+    if not pod_name:
+        return
+
+    # Delete the pod to free resources; the PVC, Secret, and CRD remain
+    core_v1 = k8s.CoreV1Api()
+    try:
+        core_v1.delete_namespaced_pod(name=pod_name, namespace=namespace)
+    except k8s.exceptions.ApiException as e:
+        if e.status == 404:
+            log.info("Pod %s/%s already gone", namespace, pod_name)
+        else:
+            raise
+
+    # Update status to Idle
+    custom_api = k8s.CustomObjectsApi()
+    try:
+        custom_api.patch_namespaced_custom_object_status(
+            group=GROUP,
+            version=VERSION,
+            namespace=namespace,
+            plural=PLURAL,
+            name=name,
+            body={
+                "status": {
+                    "phase": "Idle",
+                    "conditions": _set_condition(
+                        status,
+                        "Ready",
+                        "False",
+                        "IdleTimeout",
+                        f"Pod deleted after {elapsed:.0f} min of inactivity",
+                    ),
+                }
+            },
+        )
+    except k8s.exceptions.ApiException:
+        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,15 +12,10 @@ dependencies = [
     "uvicorn[standard]>=0.34.0",
     "click>=8.1.0",
     "httpx>=0.27.0",
-    "aiodocker>=0.23.0",
-    "sqlalchemy[asyncio]>=2.0.0",
-    "aiosqlite>=0.21.0",
-    "alembic>=1.15.0",
     "pydantic-settings>=2.0.0",
     "websockets>=13.0",
     "loguru>=0.7.3",
     "kubernetes-asyncio>=31.0.0",
-    "cryptography>=44.0.0",
 ]
 
 [project.scripts]

--- a/terminals/backends/base.py
+++ b/terminals/backends/base.py
@@ -1,6 +1,7 @@
 """Abstract base class for terminal backends."""
 
 from abc import ABC, abstractmethod
+from typing import Optional
 
 
 class Backend(ABC):
@@ -32,3 +33,37 @@ class Backend(ABC):
     @abstractmethod
     async def close(self) -> None:
         """Release resources on shutdown."""
+
+    # ------------------------------------------------------------------
+    # Optional methods for DB-free operation
+    # ------------------------------------------------------------------
+
+    async def ensure_terminal(self, user_id: str) -> Optional[dict]:
+        """Get-or-create a terminal for *user_id*.
+
+        Returns a dict with ``api_key``, ``host``, ``port`` (and optionally
+        ``instance_id``, ``instance_name``), or ``None`` if the terminal
+        could not be resolved.
+
+        The default implementation delegates to :meth:`provision`, which is
+        already idempotent for most backends.  Backends with their own
+        state store (e.g. Kubernetes CRDs) can override this to avoid
+        requiring a database.
+        """
+        return await self.provision(user_id)
+
+    async def get_terminal_info(self, user_id: str) -> Optional[dict]:
+        """Look up an existing terminal without creating one.
+
+        Returns the same dict shape as :meth:`ensure_terminal`, or ``None``
+        if no terminal exists for *user_id*.  The default returns ``None``;
+        backends that maintain their own state should override.
+        """
+        return None
+
+    async def touch_activity(self, user_id: str) -> None:
+        """Record that *user_id*'s terminal is actively being used.
+
+        Backends that track idle time should override this to update the
+        last-activity timestamp.  The default is a no-op.
+        """

--- a/terminals/backends/kubernetes_operator.py
+++ b/terminals/backends/kubernetes_operator.py
@@ -2,13 +2,17 @@
 
 Instead of creating Pods/Services directly, this backend creates and manages
 ``Terminal`` custom resources.  A separate Kopf-based operator watches these
-CRs and reconciles the underlying Pods, Services, and PVCs.
+CRs and reconciles the underlying Pods, Services, Secrets, and PVCs.
+
+The operator generates API keys and stores them in Kubernetes Secrets.
+This backend reads the key from the Secret referenced in ``status.apiKeySecret``.
 """
 
 import asyncio
+import base64
+import hashlib
 import logging
 import re
-import secrets
 from typing import Optional
 
 from kubernetes_asyncio import client, config
@@ -27,9 +31,9 @@ _DNS_SAFE = re.compile(r"[^a-z0-9-]")
 
 
 def _sanitize_name(user_id: str) -> str:
-    """Convert a user ID to a DNS-safe K8s resource name."""
-    name = _DNS_SAFE.sub("-", user_id.lower()).strip("-")[:53]
-    return f"terminal-{name}"
+    """Deterministic, DNS-safe Terminal CR name from a user ID."""
+    short = hashlib.sha256(user_id.encode()).hexdigest()[:12]
+    return f"terminal-{short}"
 
 
 class KubernetesOperatorBackend(Backend):
@@ -37,7 +41,7 @@ class KubernetesOperatorBackend(Backend):
 
     The backend creates/deletes ``Terminal`` custom resources in the
     configured namespace.  A Kopf operator running in the cluster watches
-    these resources and manages the actual Pods, Services, and PVCs.
+    these resources and manages the actual Pods, Services, Secrets, and PVCs.
     """
 
     def __init__(self) -> None:
@@ -67,14 +71,46 @@ class KubernetesOperatorBackend(Backend):
         return "terminals"
 
     # ------------------------------------------------------------------
-    # Backend interface
+    # Internal helpers
     # ------------------------------------------------------------------
 
-    async def provision(self, user_id: str) -> dict:
+    async def _read_api_key_from_secret(self, secret_name: str) -> Optional[str]:
+        """Read the API key from a Kubernetes Secret."""
+        api_client = await self._ensure_client()
+        core = client.CoreV1Api(api_client)
+        ns = settings.kubernetes_namespace
+        try:
+            secret = await core.read_namespaced_secret(secret_name, ns)
+            raw = secret.data.get("api-key", "")
+            return base64.b64decode(raw).decode() if raw else None
+        except client.exceptions.ApiException as e:
+            if e.status == 404:
+                return None
+            raise
+
+    async def _get_terminal_cr(self, user_id: str) -> Optional[dict]:
+        """Get the Terminal CR for a user, or None if it doesn't exist."""
         api_client = await self._ensure_client()
         custom = client.CustomObjectsApi(api_client)
+        name = _sanitize_name(user_id)
+        ns = settings.kubernetes_namespace
+        try:
+            return await custom.get_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=ns,
+                plural=self._plural,
+                name=name,
+            )
+        except client.exceptions.ApiException as e:
+            if e.status == 404:
+                return None
+            raise
 
-        api_key = secrets.token_urlsafe(24)
+    async def _create_terminal_cr(self, user_id: str) -> dict:
+        """Create a Terminal CR for a user and return it."""
+        api_client = await self._ensure_client()
+        custom = client.CustomObjectsApi(api_client)
         name = _sanitize_name(user_id)
         ns = settings.kubernetes_namespace
 
@@ -93,77 +129,261 @@ class KubernetesOperatorBackend(Backend):
             "spec": {
                 "userId": user_id,
                 "image": settings.kubernetes_image,
-                "apiKey": api_key,
-                "storage": {
-                    "enabled": bool(settings.kubernetes_storage_size),
-                    "size": settings.kubernetes_storage_size,
-                    "storageClass": settings.kubernetes_storage_class or None,
+                "resources": {
+                    "requests": {
+                        "cpu": settings.kubernetes_default_cpu_request,
+                        "memory": settings.kubernetes_default_memory_request,
+                    },
+                    "limits": {
+                        "cpu": settings.kubernetes_default_cpu_limit,
+                        "memory": settings.kubernetes_default_memory_limit,
+                    },
+                },
+                "idleTimeoutMinutes": settings.kubernetes_default_idle_timeout_minutes,
+                "packages": [],
+                "pipPackages": [],
+                "persistence": {
+                    "enabled": settings.kubernetes_default_persistence_enabled,
+                    "size": settings.kubernetes_default_persistence_size,
+                    "storageClass": settings.kubernetes_storage_class or "",
                 },
             },
         }
 
         try:
-            created = await custom.create_namespaced_custom_object(
+            return await custom.create_namespaced_custom_object(
                 group=self._group,
                 version=self._version,
                 namespace=ns,
                 plural=self._plural,
                 body=cr,
             )
-            log.info("Created Terminal CR %s in %s", name, ns)
         except client.exceptions.ApiException as exc:
             if exc.status == 409:
-                # Already exists — fetch it.
-                log.debug("Terminal CR %s already exists", name)
-                created = await custom.get_namespaced_custom_object(
+                # Already exists — but may be mid-deletion (finalizer pending).
+                existing = await self._get_terminal_cr(user_id)
+                if existing and existing.get("metadata", {}).get("deletionTimestamp"):
+                    # CR is being deleted; wait for it to vanish, then retry create
+                    await self._wait_for_deletion(user_id, timeout=60)
+                    return await custom.create_namespaced_custom_object(
+                        group=self._group,
+                        version=self._version,
+                        namespace=ns,
+                        plural=self._plural,
+                        body=cr,
+                    )
+                if existing:
+                    return existing
+                # Gone between the 409 and our GET — safe to retry
+                return await custom.create_namespaced_custom_object(
+                    group=self._group,
+                    version=self._version,
+                    namespace=ns,
+                    plural=self._plural,
+                    body=cr,
+                )
+            raise
+
+    async def _delete_terminal_cr(self, user_id: str, wait: bool = True, timeout: int = 60) -> bool:
+        """Delete the Terminal CR for a user and optionally wait for it to be gone.
+
+        When *wait* is True (default), polls until the CR returns 404 so that
+        a subsequent create won't collide with the kopf finalizer.
+        """
+        api_client = await self._ensure_client()
+        custom = client.CustomObjectsApi(api_client)
+        name = _sanitize_name(user_id)
+        ns = settings.kubernetes_namespace
+        try:
+            await custom.delete_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=ns,
+                plural=self._plural,
+                name=name,
+            )
+        except client.exceptions.ApiException as e:
+            if e.status == 404:
+                return False
+            raise
+
+        if not wait:
+            return True
+
+        # Poll until the CR is fully removed (finalizer may delay deletion)
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                await custom.get_namespaced_custom_object(
                     group=self._group,
                     version=self._version,
                     namespace=ns,
                     plural=self._plural,
                     name=name,
                 )
-            else:
+            except client.exceptions.ApiException as e:
+                if e.status == 404:
+                    return True
                 raise
+            await asyncio.sleep(1)
 
-        instance_id = created["metadata"]["uid"]
+        log.warning("Terminal CR %s not fully deleted after %ds", name, timeout)
+        return True
 
-        # Wait for the operator to set status.phase = Running.
-        host = await self._wait_for_ready(name, ns, timeout=60)
+    async def _wait_for_deletion(self, user_id: str, timeout: int = 60) -> None:
+        """Poll until a Terminal CR no longer exists (404)."""
+        api_client = await self._ensure_client()
+        custom = client.CustomObjectsApi(api_client)
+        name = _sanitize_name(user_id)
+        ns = settings.kubernetes_namespace
 
-        return {
-            "instance_id": instance_id,
-            "instance_name": name,
-            "api_key": api_key,
-            "host": host,
-            "port": 8000,
-        }
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                await custom.get_namespaced_custom_object(
+                    group=self._group,
+                    version=self._version,
+                    namespace=ns,
+                    plural=self._plural,
+                    name=name,
+                )
+            except client.exceptions.ApiException as e:
+                if e.status == 404:
+                    return
+                raise
+            await asyncio.sleep(1)
 
-    async def start(self, instance_id: str) -> bool:
-        """Signal the operator to bring the terminal back up.
+        log.warning("Terminal CR %s still exists after %ds wait", name, timeout)
 
-        The operator watches for ``spec.replicas`` changes and
-        creates/deletes the Pod accordingly.
+    async def _wait_for_ready(
+        self, name: str, namespace: str, timeout: int = 120
+    ) -> Optional[dict]:
+        """Poll the CR status until Running with serviceUrl and apiKeySecret.
+
+        Returns a dict with ``service_url`` and ``api_key``, or None on timeout.
         """
+        api_client = await self._ensure_client()
+        custom = client.CustomObjectsApi(api_client)
+
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            try:
+                cr = await custom.get_namespaced_custom_object(
+                    group=self._group,
+                    version=self._version,
+                    namespace=namespace,
+                    plural=self._plural,
+                    name=name,
+                )
+                status = cr.get("status", {})
+                if (
+                    status.get("phase") == "Running"
+                    and status.get("serviceUrl")
+                    and status.get("apiKeySecret")
+                ):
+                    api_key = await self._read_api_key_from_secret(status["apiKeySecret"])
+                    if api_key:
+                        return {
+                            "service_url": status["serviceUrl"],
+                            "api_key": api_key,
+                        }
+            except client.exceptions.ApiException:
+                pass
+            await asyncio.sleep(2)
+
+        log.warning(
+            "Terminal CR %s did not reach Running in %ds",
+            name,
+            timeout,
+        )
+        return None
+
+    async def _name_from_uid(self, uid: str) -> Optional[str]:
+        """Look up a Terminal CR name by its UID."""
         api_client = await self._ensure_client()
         custom = client.CustomObjectsApi(api_client)
         ns = settings.kubernetes_namespace
 
+        try:
+            result = await custom.list_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=ns,
+                plural=self._plural,
+                label_selector="app.kubernetes.io/managed-by=terminals",
+            )
+            for item in result.get("items", []):
+                if item["metadata"]["uid"] == uid:
+                    return item["metadata"]["name"]
+        except client.exceptions.ApiException:
+            pass
+        return None
+
+    def _parse_service_url(self, service_url: str) -> tuple[str, int]:
+        """Extract host and port from a service URL like http://svc:8000."""
+        url = service_url.rstrip("/")
+        if "://" in url:
+            url = url.split("://", 1)[1]
+        if ":" in url:
+            host, port_str = url.rsplit(":", 1)
+            return host, int(port_str)
+        return url, 8000
+
+    # ------------------------------------------------------------------
+    # Backend interface
+    # ------------------------------------------------------------------
+
+    async def provision(self, user_id: str) -> Optional[dict]:
+        """Create a Terminal CR and wait for it to become ready.
+
+        Returns connection info dict or ``None`` on timeout.
+        """
+        cr = await self._create_terminal_cr(user_id)
+        name = cr["metadata"]["name"]
+        ns = settings.kubernetes_namespace
+
+        ready = await self._wait_for_ready(name, ns, timeout=120)
+        if ready:
+            host, port = self._parse_service_url(ready["service_url"])
+            return {
+                "instance_id": cr["metadata"]["uid"],
+                "instance_name": name,
+                "api_key": ready["api_key"],
+                "host": host,
+                "port": port,
+            }
+
+        return None
+
+    async def start(self, instance_id: str) -> bool:
+        """For idle terminals, delete and re-create the CR."""
         name = await self._name_from_uid(instance_id)
         if name is None:
             return False
 
+        api_client = await self._ensure_client()
+        custom = client.CustomObjectsApi(api_client)
+        ns = settings.kubernetes_namespace
+
         try:
-            await custom.patch_namespaced_custom_object(
+            cr = await custom.get_namespaced_custom_object(
                 group=self._group,
                 version=self._version,
                 namespace=ns,
                 plural=self._plural,
                 name=name,
-                body={"spec": {"replicas": 1}},
             )
-            return True
         except client.exceptions.ApiException:
             return False
+
+        phase = cr.get("status", {}).get("phase")
+        if phase == "Running":
+            return True
+        if phase in ("Pending", "Provisioning"):
+            return True  # still coming up
+
+        # Idle or Error — delete and let the caller re-provision
+        return False
 
     async def teardown(self, instance_id: str) -> None:
         api_client = await self._ensure_client()
@@ -211,7 +431,7 @@ class KubernetesOperatorBackend(Backend):
                 return "running"
             if phase in ("Provisioning", "Pending"):
                 return "running"  # still coming up
-            if phase == "Stopped":
+            if phase == "Idle":
                 return "stopped"
             return "stopped"
         except client.exceptions.ApiException:
@@ -223,61 +443,102 @@ class KubernetesOperatorBackend(Backend):
             self._api_client = None
 
     # ------------------------------------------------------------------
-    # Internal helpers
+    # DB-free operation
     # ------------------------------------------------------------------
 
-    async def _name_from_uid(self, uid: str) -> Optional[str]:
-        """Look up a Terminal CR name by its UID."""
+    async def ensure_terminal(self, user_id: str) -> Optional[dict]:
+        """Get or create a terminal, resolving from K8s CRDs.
+
+        Mirrors the reference ``ensure_terminal`` pattern:
+        - If no CR exists → create and wait for ready.
+        - If Idle → delete CR and re-create (operator spawns fresh pod).
+        - If Running → return connection info immediately.
+        - If Pending/Provisioning → wait for ready.
+
+        Returns a dict with ``api_key``, ``host``, ``port`` or ``None``.
+        """
+        cr = await self._get_terminal_cr(user_id)
+
+        if cr is None:
+            return await self.provision(user_id)
+
+        status = cr.get("status") or {}
+        phase = status.get("phase")
+
+        if phase == "Idle":
+            # Terminal was idled — delete and re-create to spawn a fresh pod
+            await self._delete_terminal_cr(user_id)
+            return await self.provision(user_id)
+
+        if phase == "Running" and status.get("serviceUrl") and status.get("apiKeySecret"):
+            api_key = await self._read_api_key_from_secret(status["apiKeySecret"])
+            if api_key:
+                host, port = self._parse_service_url(status["serviceUrl"])
+                return {
+                    "instance_id": cr["metadata"]["uid"],
+                    "instance_name": cr["metadata"]["name"],
+                    "api_key": api_key,
+                    "host": host,
+                    "port": port,
+                }
+
+        # Still provisioning — wait for the operator to bring it up
+        name = cr["metadata"]["name"]
+        ns = settings.kubernetes_namespace
+        ready = await self._wait_for_ready(name, ns, timeout=120)
+        if ready:
+            host, port = self._parse_service_url(ready["service_url"])
+            return {
+                "instance_id": cr["metadata"]["uid"],
+                "instance_name": cr["metadata"]["name"],
+                "api_key": ready["api_key"],
+                "host": host,
+                "port": port,
+            }
+
+        return None
+
+    async def get_terminal_info(self, user_id: str) -> Optional[dict]:
+        """Look up an existing terminal from the K8s CRD without creating one."""
+        cr = await self._get_terminal_cr(user_id)
+        if cr is None:
+            return None
+
+        status = cr.get("status") or {}
+        phase = status.get("phase")
+
+        if phase == "Running" and status.get("serviceUrl") and status.get("apiKeySecret"):
+            api_key = await self._read_api_key_from_secret(status["apiKeySecret"])
+            if api_key:
+                host, port = self._parse_service_url(status["serviceUrl"])
+                return {
+                    "instance_id": cr["metadata"]["uid"],
+                    "instance_name": cr["metadata"]["name"],
+                    "api_key": api_key,
+                    "host": host,
+                    "port": port,
+                }
+
+        return None
+
+    async def touch_activity(self, user_id: str) -> None:
+        """Update lastActivityAt on the Terminal CR to prevent idle culling."""
         api_client = await self._ensure_client()
         custom = client.CustomObjectsApi(api_client)
+        name = _sanitize_name(user_id)
         ns = settings.kubernetes_namespace
-
+        from datetime import datetime, timezone
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         try:
-            result = await custom.list_namespaced_custom_object(
+            await custom.patch_namespaced_custom_object_status(
                 group=self._group,
                 version=self._version,
                 namespace=ns,
                 plural=self._plural,
-                label_selector="app.kubernetes.io/managed-by=terminals",
+                name=name,
+                body={"status": {"lastActivityAt": now}},
+                _content_type="application/merge-patch+json",
             )
-            for item in result.get("items", []):
-                if item["metadata"]["uid"] == uid:
-                    return item["metadata"]["name"]
-        except client.exceptions.ApiException:
-            pass
-        return None
-
-    async def _wait_for_ready(
-        self, name: str, namespace: str, timeout: int = 60
-    ) -> str:
-        """Poll the CR status until the operator reports it as Running.
-
-        Returns the service hostname set by the operator.
-        """
-        api_client = await self._ensure_client()
-        custom = client.CustomObjectsApi(api_client)
-
-        deadline = asyncio.get_event_loop().time() + timeout
-        while asyncio.get_event_loop().time() < deadline:
-            try:
-                cr = await custom.get_namespaced_custom_object(
-                    group=self._group,
-                    version=self._version,
-                    namespace=namespace,
-                    plural=self._plural,
-                    name=name,
-                )
-                status = cr.get("status", {})
-                if status.get("phase") == "Running" and status.get("host"):
-                    return status["host"]
-            except client.exceptions.ApiException:
-                pass
-            await asyncio.sleep(2)
-
-        # Timed out — return the expected FQDN anyway; proxy will retry.
-        log.warning(
-            "Terminal CR %s did not reach Running in %ds, returning expected host",
-            name,
-            timeout,
-        )
-        return f"{name}.{namespace}.svc.cluster.local"
+        except client.exceptions.ApiException as e:
+            if e.status != 404:
+                log.warning("Failed to touch activity for %s: %s", name, e)

--- a/terminals/config.py
+++ b/terminals/config.py
@@ -8,7 +8,6 @@ class Settings(BaseSettings):
 
     api_key: str = ""
     open_webui_url: str = ""  # if set, validate JWTs against this Open WebUI instance
-    database_url: str = "sqlite+aiosqlite:///./data/terminals.db"
 
     # Backend selection: "docker", "local", or "static"
     backend: str = "docker"
@@ -42,6 +41,15 @@ class Settings(BaseSettings):
     # Operator-specific settings
     kubernetes_crd_group: str = "openwebui.com"
     kubernetes_crd_version: str = "v1alpha1"
+
+    # Operator resource defaults (applied to Terminal CRs)
+    kubernetes_default_cpu_request: str = "100m"
+    kubernetes_default_cpu_limit: str = "1"
+    kubernetes_default_memory_request: str = "256Mi"
+    kubernetes_default_memory_limit: str = "1Gi"
+    kubernetes_default_idle_timeout_minutes: int = 30
+    kubernetes_default_persistence_enabled: bool = True
+    kubernetes_default_persistence_size: str = "1Gi"
 
     # Lifecycle management
     idle_timeout_seconds: int = 1800   # 30 min — stop instances idle this long

--- a/terminals/db/session.py
+++ b/terminals/db/session.py
@@ -3,20 +3,23 @@
 import os
 from pathlib import Path
 
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-
 from terminals.config import settings
 
-# Ensure the directory for the SQLite file exists.
-_db_url = settings.database_url
-if _db_url.startswith("sqlite"):
-    # Extract path from  sqlite+aiosqlite:///path/to/db
-    _db_path = _db_url.split("///", 1)[-1]
-    if _db_path:
-        os.makedirs(os.path.dirname(_db_path) or ".", exist_ok=True)
+engine = None
+async_session = None
 
-engine = create_async_engine(settings.database_url, echo=False)
-async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+_db_url = settings.database_url
+if _db_url:
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+    # Ensure the directory for the SQLite file exists.
+    if _db_url.startswith("sqlite"):
+        _db_path = _db_url.split("///", 1)[-1]
+        if _db_path:
+            os.makedirs(os.path.dirname(_db_path) or ".", exist_ok=True)
+
+    engine = create_async_engine(_db_url, echo=False)
+    async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
 
 async def init_db():
@@ -43,4 +46,5 @@ async def init_db():
 
 async def close_db():
     """Dispose of the engine's connection pool."""
-    await engine.dispose()
+    if engine is not None:
+        await engine.dispose()

--- a/terminals/main.py
+++ b/terminals/main.py
@@ -1,7 +1,5 @@
 """FastAPI application assembly."""
 
-import asyncio
-import os
 from contextlib import asynccontextmanager
 from pathlib import Path
 
@@ -10,38 +8,23 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 
 from terminals.backends import create_backend
-from terminals.db.session import close_db, init_db
-from terminals.lifecycle import run_lifecycle_loop
+from terminals.config import settings
 from terminals.logging import setup_logging
 from terminals.middleware import RequestIdMiddleware
 from terminals.routers.proxy import close_proxy_client, router as proxy_router
-from terminals.routers.tenants import router as tenants_router
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Startup / shutdown lifecycle."""
     setup_logging()
-    await init_db()
-    app.state.backend = create_backend()
 
-    # Start background lifecycle manager.
-    lifecycle_task = asyncio.create_task(
-        run_lifecycle_loop(app.state.backend)
-    )
+    app.state.backend = create_backend()
 
     yield
 
-    # Cancel lifecycle manager on shutdown.
-    lifecycle_task.cancel()
-    try:
-        await lifecycle_task
-    except asyncio.CancelledError:
-        pass
-
     await close_proxy_client()
     await app.state.backend.close()
-    await close_db()
 
 
 app = FastAPI(
@@ -49,6 +32,7 @@ app = FastAPI(
     description="Multi-tenant terminal orchestrator for Open Terminal.",
     version="0.1.0",
     lifespan=lifespan,
+    openapi_url=None,  # Disable built-in OpenAPI; proxy router serves the terminal spec
 )
 
 app.add_middleware(RequestIdMiddleware)
@@ -60,13 +44,13 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.include_router(tenants_router, prefix="/api/v1")
-app.include_router(proxy_router)
-
-
 @app.get("/health")
 async def health():
     return {"status": True}
+
+
+# Catch-all proxy router must be last so /health is matched first.
+app.include_router(proxy_router)
 
 
 # ---------------------------------------------------------------------------

--- a/terminals/routers/auth.py
+++ b/terminals/routers/auth.py
@@ -1,0 +1,97 @@
+"""Authentication dependencies for the proxy and API routes."""
+
+from typing import Optional
+
+import httpx
+from fastapi import Depends, Header, HTTPException
+
+from terminals.config import settings
+
+_owui_client: Optional[httpx.AsyncClient] = None
+
+
+async def _get_owui_client() -> httpx.AsyncClient:
+    global _owui_client
+    if _owui_client is None:
+        _owui_client = httpx.AsyncClient(timeout=10.0)
+    return _owui_client
+
+
+async def validate_token(token: str) -> Optional[str]:
+    """Validate a bearer token against the Open WebUI instance.
+
+    Returns the verified user ID on success.
+    Raises ``HTTPException`` on failure.
+
+    Only call when ``settings.open_webui_url`` is set.
+    """
+    client = await _get_owui_client()
+    url = settings.open_webui_url.rstrip("/")
+    try:
+        resp = await client.get(
+            f"{url}/api/v1/auths/",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        if resp.status_code != 200:
+            raise HTTPException(status_code=401, detail="Invalid token")
+    except httpx.HTTPError:
+        raise HTTPException(status_code=502, detail="Failed to reach Open WebUI")
+
+    data = resp.json()
+    verified_user_id = data.get("id")
+    if not verified_user_id:
+        raise HTTPException(status_code=401, detail="Token response missing user ID")
+    return verified_user_id
+
+
+async def verify_api_key(
+    authorization: Optional[str] = Header(None),
+) -> Optional[str]:
+    """Validate the caller's token.
+
+    Supports three modes:
+      1. Open WebUI - validates the JWT against the configured Open WebUI instance
+      2. API Key    - checks against TERMINALS_API_KEY
+      3. Open       - no auth when neither is configured
+
+    Returns the verified user ID when using Open WebUI JWT validation,
+    or ``None`` for API-key / open modes (where ``X-User-Id`` is trusted).
+    """
+    # Mode 1: Open WebUI JWT validation
+    if settings.open_webui_url:
+        if not authorization:
+            raise HTTPException(status_code=401, detail="Missing Authorization header")
+        scheme, _, token = authorization.partition(" ")
+        if scheme.lower() != "bearer" or not token:
+            raise HTTPException(status_code=401, detail="Invalid Authorization header")
+        return await validate_token(token)
+
+    # Mode 2: Static API key
+    if settings.api_key:
+        if not authorization:
+            raise HTTPException(status_code=401, detail="Missing Authorization header")
+        scheme, _, token = authorization.partition(" ")
+        if scheme.lower() != "bearer" or token != settings.api_key:
+            raise HTTPException(status_code=401, detail="Invalid API key")
+        return None
+
+    # Mode 3: Open access (no key configured)
+    return None
+
+
+async def verify_user_id(
+    verified_id: Optional[str] = Depends(verify_api_key),
+    x_user_id: str = Header(..., alias="X-User-Id"),
+) -> str:
+    """Return the effective user ID after verifying against JWT identity.
+
+    In JWT mode (``open_webui_url`` configured), the user ID extracted from
+    the validated token **must** match ``X-User-Id``.  In API-key or open
+    modes the header is trusted as-is.
+    """
+    if verified_id is not None and verified_id != x_user_id:
+        raise HTTPException(
+            status_code=403,
+            detail="X-User-Id does not match authenticated identity",
+        )
+    return x_user_id

--- a/terminals/routers/proxy.py
+++ b/terminals/routers/proxy.py
@@ -9,19 +9,17 @@ instance automatically.  The path structure mirrors open-terminal exactly
 import asyncio
 import json
 import time
+from dataclasses import dataclass
 from typing import Optional
 
 import httpx
+import websockets
 from fastapi import APIRouter, BackgroundTasks, Depends, Header, Query, Request, Response, WebSocket
 from fastapi.responses import JSONResponse
 from loguru import logger
-from sqlalchemy import func
 
-from terminals.audit import log_audit
 from terminals.config import settings
-from terminals.db.session import async_session
-from terminals.models.tenants import Tenant, TenantStatus
-from terminals.routers.tenants import _get_tenant, _provision_tenant, validate_token, verify_api_key, verify_user_id
+from terminals.routers.auth import validate_token, verify_api_key, verify_user_id
 
 router = APIRouter()
 
@@ -78,55 +76,32 @@ def _request_id(request) -> Optional[str]:
 # ---------------------------------------------------------------------------
 
 
-async def _resolve_tenant(request, user_id: str) -> Tenant:
-    """Return a running tenant, auto-provisioning if needed."""
+@dataclass
+class TenantInfo:
+    """Lightweight tenant descriptor resolved from CRDs."""
+    instance_id: str
+    host: str
+    port: int
+    api_key: str
+
+
+async def _resolve_tenant(request, user_id: str) -> TenantInfo:
+    """Return a running tenant, auto-provisioning via CRD if needed."""
     backend = request.app.state.backend
-    async with async_session() as session:
-        tenant = await _get_tenant(session, user_id)
-
-        if tenant is None:
-            tenant = await _provision_tenant(request, session, user_id)
-            return tenant
-
-        # Ensure the instance is alive.
-        if tenant.instance_id:
-            running = await backend.start(tenant.instance_id)
-            if not running:
-                # Re-provision.
-                old_instance_id = tenant.instance_id
-                await backend.teardown(tenant.instance_id)
-                info = await backend.provision(user_id)
-                tenant.instance_id = info["instance_id"]
-                tenant.instance_name = info["instance_name"]
-                tenant.api_key = info["api_key"]
-                tenant.host = info["host"]
-                tenant.port = info["port"]
-                tenant.status = TenantStatus.running
-
-                # Audit re-provision (fire-and-forget since we're not in a route).
-                try:
-                    await log_audit(
-                        action="tenant_reprovisioned",
-                        severity="warning",
-                        user_id=user_id,
-                        request_id=_request_id(request),
-                        resource_type="tenant",
-                        resource_id=tenant.instance_id,
-                        detail={
-                            "old_instance_id": old_instance_id,
-                            "new_instance_id": info["instance_id"],
-                        },
-                        ip_address=_client_ip(request),
-                    )
-                except Exception:
-                    logger.warning("Failed to audit tenant re-provision")
-
-        # Touch the access timestamp for idle tracking.
-        tenant.last_accessed_at = func.now()
-        await session.commit()
-        await session.refresh(tenant)
-
-        return tenant
+    info = await backend.ensure_terminal(user_id)
+    if info is None:
+        raise RuntimeError(f"Failed to provision terminal for user {user_id}")
+    # Touch activity so the operator knows the terminal is in use.
+    try:
+        await backend.touch_activity(user_id)
+    except Exception:
+        logger.debug("touch_activity failed for user {}", user_id)
+    return TenantInfo(
+        instance_id=info["instance_id"],
+        host=info["host"],
+        port=info["port"],
+        api_key=info["api_key"],
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -167,23 +142,6 @@ async def _proxy_request(
     for h in ("transfer-encoding", "connection", "content-encoding", "content-length"):
         response_headers.pop(h, None)
 
-    # Audit the proxied request.
-    severity = "warning" if upstream.status_code >= 500 else "info"
-    if background_tasks:
-        background_tasks.add_task(
-            log_audit,
-            action="proxy_request",
-            severity=severity,
-            user_id=user_id,
-            request_id=_request_id(request),
-            resource_type="proxy",
-            resource_id=tenant.instance_id,
-            detail={"method": request.method, "path": path},
-            ip_address=_client_ip(request),
-            user_agent=_user_agent(request),
-            status_code=upstream.status_code,
-        )
-
     return Response(
         content=upstream.content,
         status_code=upstream.status_code,
@@ -199,11 +157,11 @@ _SPEC_CACHE_TTL = 300  # seconds
 _cached_spec: Optional[dict] = None
 _cached_spec_ts: float = 0.0
 
-_SYSTEM_USER_ID = "__system__"
+_SYSTEM_USER_ID = "system"
 
 
 @router.get(
-    "/terminals/openapi.json",
+    "/openapi.json",
     dependencies=[Depends(verify_api_key)],
 )
 async def get_openapi_spec(request: Request):
@@ -237,6 +195,16 @@ async def get_openapi_spec(request: Request):
             status_code=502,
         )
 
+    # Strip security schemes and per-operation security requirements.
+    # Auth is handled transparently by the orchestrator proxy — the model
+    # should not see or ask for Bearer tokens.
+    spec.pop("security", None)
+    spec.get("components", {}).pop("securitySchemes", None)
+    for _path_methods in spec.get("paths", {}).values():
+        for _op in _path_methods.values():
+            if isinstance(_op, dict):
+                _op.pop("security", None)
+
     _cached_spec = spec
     _cached_spec_ts = now
 
@@ -249,7 +217,7 @@ async def get_openapi_spec(request: Request):
 
 
 @router.api_route(
-    "/terminals/{path:path}",
+    "/{path:path}",
     methods=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"],
 )
 async def proxy(
@@ -272,7 +240,7 @@ async def proxy(
 # ---------------------------------------------------------------------------
 
 
-@router.websocket("/terminals/api/terminals/{session_id}")
+@router.websocket("/api/terminals/{session_id}")
 async def ws_terminal_proxy(
     ws: WebSocket,
     session_id: str,
@@ -293,25 +261,9 @@ async def ws_terminal_proxy(
             verified_user_id = await validate_token(token)
         except Exception:
             await ws.close(code=4001, reason="Invalid token")
-            await log_audit(
-                action="auth_failed",
-                severity="critical",
-                user_id=user_id or None,
-                resource_type="websocket",
-                detail={"reason": "JWT validation failed", "session_id": session_id},
-                ip_address=_client_ip(ws),
-            )
             return
     elif settings.api_key and token != settings.api_key:
         await ws.close(code=4001, reason="Invalid API key")
-        await log_audit(
-            action="auth_failed",
-            severity="critical",
-            user_id=user_id or None,
-            resource_type="websocket",
-            detail={"reason": "Invalid API key", "session_id": session_id},
-            ip_address=_client_ip(ws),
-        )
         return
 
     if not user_id:
@@ -321,36 +273,12 @@ async def ws_terminal_proxy(
     # In JWT mode, enforce that user_id matches the verified identity.
     if verified_user_id is not None and verified_user_id != user_id:
         await ws.close(code=4003, reason="user_id does not match authenticated identity")
-        await log_audit(
-            action="auth_failed",
-            severity="critical",
-            user_id=user_id,
-            resource_type="websocket",
-            detail={
-                "reason": "user_id mismatch",
-                "claimed": user_id,
-                "verified": verified_user_id,
-                "session_id": session_id,
-            },
-            ip_address=_client_ip(ws),
-        )
         return
 
     await ws.accept()
 
     global active_ws_connections
     active_ws_connections += 1
-
-    # Audit WS connect.
-    await log_audit(
-        action="ws_connect",
-        severity="info",
-        user_id=user_id,
-        resource_type="websocket",
-        resource_id=session_id,
-        ip_address=_client_ip(ws),
-        user_agent=_user_agent(ws),
-    )
 
     try:
         tenant = await _resolve_tenant(ws, user_id)
@@ -360,8 +288,6 @@ async def ws_terminal_proxy(
         return
 
     upstream_url = f"ws://{tenant.host}:{tenant.port}/api/terminals/{session_id}"
-
-    import websockets
 
     try:
         async with websockets.connect(upstream_url) as upstream:
@@ -379,8 +305,8 @@ async def ws_terminal_proxy(
                             await upstream.send(msg["bytes"])
                         elif "text" in msg and msg["text"]:
                             await upstream.send(msg["text"])
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug("client→upstream closed: {}", e)
 
             async def _upstream_to_client():
                 """Forward upstream → client WebSocket."""
@@ -390,8 +316,8 @@ async def ws_terminal_proxy(
                             await ws.send_bytes(message)
                         else:
                             await ws.send_text(message)
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug("upstream→client closed: {}", e)
 
             await asyncio.gather(
                 _client_to_upstream(),
@@ -402,18 +328,6 @@ async def ws_terminal_proxy(
         logger.error("WebSocket terminal proxy error: {}", e)
     finally:
         active_ws_connections -= 1
-        # Audit WS disconnect.
-        try:
-            await log_audit(
-                action="ws_disconnect",
-                severity="info",
-                user_id=user_id,
-                resource_type="websocket",
-                resource_id=session_id,
-                ip_address=_client_ip(ws),
-            )
-        except Exception:
-            pass
         try:
             await ws.close()
         except Exception:


### PR DESCRIPTION
# Problem
The Kubernetes operator backend had several issues preventing reliable end-to-end operation with Open WebUI:
- Database dependency was unnecessary — the operator backend stores all state in Kubernetes CRDs, but the orchestrator still required a SQL database for tenant tracking, creating redundant state and operational complexity.
- Route prefix mismatch — proxy routes were prefixed with terminals (e.g. /terminals/openapi.json, /terminals/{path:path}), but Open WebUI strips the server ID from the URL before forwarding, so all requests returned 404.
- OpenAPI spec conflicts — FastAPI's built-in /openapi.json endpoint returned the orchestrator's own auto-generated schema (with X-User-Id header parameters), shadowing the open-terminal spec. Additionally, the open-terminal spec included securitySchemes that caused models to ask users for Bearer tokens instead of calling tools.
- Finalizer race conditions — when resuming an idle terminal (delete CR → re-create), the kopf finalizer could still be running on the old CR when the new create arrived, causing 409 conflicts that weren't handled.
- CRD schema gaps — the Terminal CRD was missing fields for resource limits, persistence, idle timeout configuration, and proper status reporting (serviceUrl, apiKeySecret, lastActivityAt).
- touch_activity content-type error — the status sub-resource patch used the wrong content type, causing 400 errors from the API server.

# Changes
## Orchestrator (terminals)
- Removed database dependency: _resolve_tenant now calls backend.ensure_terminal() / backend.touch_activity() directly against CRDs instead of going through SQL. Removed tenants_router import, lifecycle loop, and DB init/close from the app lifespan. Made db/session.py conditional so the engine is only created when database_url is set.
- Fixed route prefixes: Removed terminals prefix from all proxy routes (/openapi.json, /{path:path}, /api/terminals/{session_id}).
- Fixed OpenAPI serving: Set openapi_url=None on FastAPI to disable the built-in spec endpoint. The proxy router's /openapi.json now fetches the spec from the open-terminal pod, strips security and securitySchemes from the response, and caches it for 5 minutes.
- Moved /health before the catch-all router so it's matched before /{path:path}.
Extracted auth module (routers/auth.py): verify_api_key, verify_user_id, and validate_token are now in a shared module used by the proxy router.
- Removed inline audit logging from the proxy — audit events were tightly coupled to the DB-backed tenant model. Audit can be re-added at the operator level where it belongs.
- Added touch_activity() to the Backend ABC as an optional method with a default no-op.
- Added resource configuration settings to config.py: CPU/memory requests and limits, idle timeout, and persistence size.

## Operator (operator/handler.py)
- Expanded CRD schema: Added resources (requests/limits), idleTimeoutMinutes, packages, pipPackages, persistence (enabled/size/storageClass) fields to the Terminal spec.
- Status fields: The operator now sets serviceUrl, apiKeySecret, and lastActivityAt on the CR status, which the orchestrator reads directly instead of guessing hostnames.
- Idle/resume lifecycle: Proper handling of the Idle→delete→re-create flow with finalizer-aware waiting.

## Kubernetes operator backend (backends/kubernetes_operator.py)
- ensure_terminal(): New DB-free get-or-create flow — checks CRD phase (Running → return immediately, Idle → delete and re-provision, Pending → wait for ready, Missing → create).
- _create_terminal_cr(): Handles 409 conflicts by checking for deletionTimestamp and waiting for the finalizer to complete before retrying.
- _delete_terminal_cr(): Polls until 404 so subsequent creates don't collide with pending finalizers.
- _wait_for_ready(): Polls until status.phase == Running AND serviceUrl + apiKeySecret are set, then reads the API key from the referenced Secret.
- touch_activity(): Patches status.lastActivityAt using application/merge-patch+json content type.
- get_terminal_info(): Read-only lookup of existing terminal without creating one.

# Testing
Tested end-to-end in a Kind cluster with the stock Open WebUI v0.8.8 image:
- Terminal file browser works (directory listing, file read/write)
- Model successfully calls terminal tools (list_files, execute, etc.) via the chat completions API
- Idle→resume flow works without finalizer race conditions
- WebSocket terminal proxy connects correctly
- Multi-user pattern works correctly, with each new user getting their own terminal

## Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](./CLA.md), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
