### PR TITLE
feat: enable Terminals K8s Orchestrator policy management in Open WebUI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "websockets>=13.0",
     "loguru>=0.7.3",
     "kubernetes-asyncio>=31.0.0",
+    "sqlalchemy[asyncio]>=2.0.0",
+    "aiosqlite>=0.20.0",
+    "alembic>=1.13.0",
 ]
 
 [project.scripts]

--- a/terminals/backends/base.py
+++ b/terminals/backends/base.py
@@ -65,6 +65,32 @@ class Backend(ABC):
     async def close(self) -> None:
         """Release resources on shutdown."""
 
+    async def list_instances(self) -> list[dict]:
+        """Return all tracked terminal instances with status info.
+
+        Each dict contains at least: ``user_id``, ``policy_id``,
+        ``instance_id``, ``status``, ``instance_name``.
+
+        Backends may override for richer information (e.g. querying CRDs).
+        The default implementation returns in-memory tracked instances.
+        """
+        results = []
+        for key, info in list(self._instances.items()):
+            parts = key.split(":", 1)
+            user_id = parts[0]
+            policy_id = parts[1] if len(parts) > 1 else "default"
+            st = await self.status(info["instance_id"])
+            results.append({
+                "user_id": user_id,
+                "policy_id": policy_id,
+                "instance_id": info["instance_id"],
+                "instance_name": info.get("instance_name", ""),
+                "status": st,
+                "host": info.get("host", ""),
+                "port": info.get("port", 0),
+            })
+        return results
+
     # ------------------------------------------------------------------
     # Instance tracking
     # ------------------------------------------------------------------

--- a/terminals/backends/kubernetes_operator.py
+++ b/terminals/backends/kubernetes_operator.py
@@ -611,3 +611,52 @@ class KubernetesOperatorBackend(Backend):
         except client.exceptions.ApiException as e:
             if e.status != 404:
                 log.warning("Failed to touch activity for %s: %s", name, e)
+
+    async def list_instances(self) -> list[dict]:
+        """List all Terminal CRs managed by the operator.
+
+        Queries Kubernetes directly for authoritative status rather than
+        relying on in-memory tracking.
+        """
+        api_client = await self._ensure_client()
+        custom = client.CustomObjectsApi(api_client)
+        ns = settings.kubernetes_namespace
+
+        try:
+            result = await custom.list_namespaced_custom_object(
+                group=self._group,
+                version=self._version,
+                namespace=ns,
+                plural=self._plural,
+                label_selector="app.kubernetes.io/managed-by=terminals",
+            )
+        except client.exceptions.ApiException:
+            log.exception("Failed to list Terminal CRs")
+            return []
+
+        instances = []
+        for item in result.get("items", []):
+            metadata = item.get("metadata", {})
+            spec = item.get("spec", {})
+            status = item.get("status", {})
+            labels = metadata.get("labels", {})
+
+            instances.append({
+                "user_id": spec.get("userId", labels.get("openwebui.com/user-id", "")),
+                "policy_id": labels.get("openwebui.com/policy", "default"),
+                "instance_id": metadata.get("uid", ""),
+                "instance_name": metadata.get("name", ""),
+                "status": (status.get("phase") or "Unknown").lower(),
+                "host": status.get("serviceName", ""),
+                "port": 8000,
+                "image": spec.get("image", ""),
+                "cpu_limit": spec.get("cpuLimit", ""),
+                "memory_limit": spec.get("memoryLimit", ""),
+                "storage": spec.get("storage", ""),
+                "idle_timeout_minutes": spec.get("idleTimeoutMinutes", 0),
+                "last_activity": status.get("lastActivityAt", ""),
+                "created_at": metadata.get("creationTimestamp", ""),
+                "message": status.get("message", ""),
+            })
+
+        return instances

--- a/terminals/main.py
+++ b/terminals/main.py
@@ -62,9 +62,11 @@ async def health():
 
 
 from terminals.routers.policy import router as policy_router
+from terminals.routers.instances import router as instances_router
 
 # Policy CRUD must be before the catch-all proxy.
 app.include_router(policy_router)
+app.include_router(instances_router)
 
 # Catch-all proxy router must be last so /health and /api are matched first.
 app.include_router(proxy_router)

--- a/terminals/routers/instances.py
+++ b/terminals/routers/instances.py
@@ -1,0 +1,88 @@
+"""Terminal instance listing and management API."""
+
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+
+from terminals.config import settings
+from terminals.routers.auth import verify_api_key
+
+log = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1", tags=["instances"])
+
+
+# ---------------------------------------------------------------------------
+# Pydantic schemas
+# ---------------------------------------------------------------------------
+
+
+class InstanceResponse(BaseModel):
+    user_id: str
+    policy_id: str
+    instance_id: str
+    instance_name: str
+    status: str
+    host: str = ""
+    port: int = 0
+    image: str = ""
+    cpu_limit: str = ""
+    memory_limit: str = ""
+    storage: str = ""
+    idle_timeout_minutes: int = 0
+    last_activity: str = ""
+    created_at: str = ""
+    message: str = ""
+
+
+class InfoResponse(BaseModel):
+    backend: str
+    version: str = "0.1.0"
+    max_cpu: str = ""
+    max_memory: str = ""
+    max_storage: str = ""
+    allowed_images: str = ""
+    idle_timeout_minutes: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.get("/instances", dependencies=[Depends(verify_api_key)])
+async def list_instances(request: Request) -> list[InstanceResponse]:
+    """List all active terminal instances."""
+    backend = request.app.state.backend
+    instances = await backend.list_instances()
+    return [InstanceResponse(**inst) for inst in instances]
+
+
+@router.delete(
+    "/instances/{instance_id}",
+    dependencies=[Depends(verify_api_key)],
+)
+async def teardown_instance(instance_id: str, request: Request):
+    """Force-teardown a specific terminal instance."""
+    backend = request.app.state.backend
+    try:
+        await backend.teardown(instance_id)
+    except Exception:
+        log.exception("Failed to teardown instance %s", instance_id)
+        raise HTTPException(status_code=500, detail="Failed to teardown instance")
+    return {"ok": True}
+
+
+@router.get("/info", dependencies=[Depends(verify_api_key)])
+async def get_info() -> InfoResponse:
+    """Return server info including backend type and resource caps."""
+    return InfoResponse(
+        backend=settings.backend,
+        max_cpu=settings.max_cpu,
+        max_memory=settings.max_memory,
+        max_storage=settings.max_storage,
+        allowed_images=settings.allowed_images,
+        idle_timeout_minutes=settings.idle_timeout_minutes,
+    )


### PR DESCRIPTION
# Description

## Summary

Adds three new API endpoints to the Terminals orchestrator that enable Open WebUI admins to manage terminal instances and inspect server configuration through the UI. This is the Terminals-side half of a two-PR effort. The companion [Open WebUI PR](https://github.com/open-webui/open-webui/pull/23011) adds the admin proxy routes and frontend UI that consume these endpoints.

## Motivation

### Why this is needed

The Kubernetes Operator backend (`kubernetes-operator`) creates and manages Terminal CRDs, but until now there was no way for administrators to:

1. **See what terminal instances are running** — which users have active terminals, what policy governs each one, and what state they're in.
2. **Tear down a specific instance** — for example, to reclaim resources or force-restart a misbehaving terminal.
3. **Inspect the server's configuration** — what backend is in use, what resource caps are enforced, etc.

These capabilities are prerequisites for the admin UI integration in Open WebUI, where admins need visibility into deployed terminals and the ability to act on them.

### Why it lives in the Terminals service

Policy CRUD already exists in `terminals/routers/policy.py`. Instance listing and server info are the natural complement — they let the admin see "what's configured" (policies) alongside "what's running" (instances) and "what's allowed" (server info / resource caps). Keeping these in the orchestrator means Open WebUI simply proxies to them, staying decoupled from Kubernetes details.

## Changes

### New file: `terminals/routers/instances.py` (+88 lines)

Three new endpoints, all behind `verify_api_key` authentication:

| Endpoint | Method | Purpose |
|---|---|---|
| `/api/v1/instances` | GET | List all active terminal instances with status, resource config, timestamps |
| `/api/v1/instances/{instance_id}` | DELETE | Force-teardown a specific instance by ID |
| `/api/v1/info` | GET | Return server metadata: backend type, version, resource caps (max CPU/memory/storage), allowed images, idle timeout |

**Response schemas:**

- `InstanceResponse` — `user_id`, `policy_id`, `instance_id`, `instance_name`, `status`, `host`, `port`, `image`, `cpu_limit`, `memory_limit`, `storage`, `idle_timeout_minutes`, `last_activity`, `created_at`, `message`
- `InfoResponse` — `backend`, `version`, `max_cpu`, `max_memory`, `max_storage`, `allowed_images`, `idle_timeout_minutes`

### Modified: `terminals/backends/base.py` (+26 lines)

Added a default `list_instances()` method to the `Backend` ABC that returns instance info from the in-memory `_instances` tracking dict. This provides a working implementation for all backends (Docker, Local, Static) without requiring backend-specific overrides.

Each returned dict includes: `user_id`, `policy_id`, `instance_id`, `instance_name`, `status`, `host`, `port`. Status is fetched live via `self.status()`.

### Modified: `terminals/backends/kubernetes_operator.py` (+49 lines)

Overrides `list_instances()` to query Kubernetes directly rather than relying on in-memory tracking. This is important because:

- The orchestrator process may restart, losing in-memory state, but Terminal CRs persist.
- Multiple orchestrator replicas won't share in-memory state.
- Kubernetes is the source of truth for CRD-managed resources.

The implementation:
1. Calls `list_namespaced_custom_object()` with label selector `app.kubernetes.io/managed-by=terminals`
2. Maps CRD fields (spec, status, metadata, labels) to the `InstanceResponse` schema
3. Extracts `userId`, `image`, `cpuLimit`, `memoryLimit`, `storage`, `idleTimeoutMinutes` from spec
4. Extracts `phase`, `serviceName`, `lastActivityAt`, `message` from status
5. Extracts `openwebui.com/user-id` and `openwebui.com/policy` from labels

### Modified: `terminals/main.py` (+2 lines)

Registers the new `instances_router` alongside the existing `policy_router`, both before the catch-all proxy router.

### Modified: `pyproject.toml` (+3 lines)

Added `sqlalchemy[asyncio]>=2.0.0`, `aiosqlite>=0.20.0`, `alembic>=1.13.0` to dependencies. These are required by the existing DB layer (`terminals/db/session.py`) but were previously missing from the declared dependencies.

## Design decisions

### Why a default implementation on the base class?

The base `Backend` uses in-memory `_instances` tracking (`self._instances` dict populated by `_track`/`_untrack` calls). Adding `list_instances()` there means Docker, Local, and Static backends get instance listing for free. The Kubernetes Operator backend overrides it because CRDs are the authoritative source, and in-memory tracking is best-effort for that backend.

### Why `/api/v1/info` rather than extending `/health`?

`/health` is unauthenticated (used by load balancers and readiness probes). Server info includes configuration details that should only be visible to authenticated administrators, so it lives behind `verify_api_key` on a separate endpoint.

### Why does the teardown endpoint accept `instance_id` (UID), not instance name?

The backend `teardown()` method already operates on instance IDs (Kubernetes UIDs for the operator backend). Using the UID avoids ambiguity if names are reused and aligns with the existing `teardown()` contract.

## Testing

Tested end-to-end on a local `kind` cluster with the Kubernetes Operator backend:

1. **Policy CRUD**: Created policies with varying resource limits, verified they're stored and retrievable.
2. **Instance listing**: Provisioned terminals for multiple users via different policies, verified `/api/v1/instances` returns correct user_id, policy_id, status, and resource info for each.
3. **Instance teardown**: Called `DELETE /api/v1/instances/{uid}`, verified the Terminal CR was deleted and the instance disappeared from subsequent list calls.
4. **Server info**: Verified `/api/v1/info` returns the correct backend type (`kubernetes-operator`), resource caps from environment variables, and version.
5. **Auth**: Verified all three endpoints return 401/403 without a valid API key.
6. **Frontend**: Tested that the Open WebUI frontend shows the expected information about terminals spun up through the Orchestrator, including each Terminal endpoint, Policies, and Active Terminals. Screenshots of the most up-to-date implementation are present in the Open WebUI PR. 

# Related PRs
The Open WebUI PR adds:
- Backend proxy routes that forward admin requests to these endpoints
- Frontend components: policy management UI, instance monitoring table, server info display
- Tabbed admin interface under Settings → Integrations → Terminals

The associated PR can be found in Open WebUI here: https://github.com/open-webui/open-webui/pull/23011
---

# Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [ x ] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](./CLA.md), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
