### PR TITLE
fix: add required dependencies to run terminals

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ dependencies = [
     "websockets>=13.0",
     "loguru>=0.7.3",
     "kubernetes-asyncio>=31.0.0",
+    "aiodocker>=0.23.0",
+    "sqlalchemy[asyncio]>=2.0.0",
+    "aiosqlite>=0.20.0",
+    "alembic>=1.13.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Description

Adds missing dependencies to `pyproject.toml` so that Terminals can be started successfully.

## Related Issues

Closes https://github.com/open-webui/terminals/issues/7

---

## Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](./CLA.md), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
