### PR TITLE
fix: resolve paths relative to package directory, not CWD

### DIFF
--- a/terminals/cli.py
+++ b/terminals/cli.py
@@ -81,10 +81,13 @@ def _alembic_cfg():
         cfg = Config(str(ini_path))
     else:
         cfg = Config()
-        cfg.set_main_option(
-            "script_location",
-            str(Path(__file__).resolve().parent / "migrations"),
-        )
+
+    # Always resolve script_location to an absolute path so the CLI works
+    # regardless of the current working directory.
+    cfg.set_main_option(
+        "script_location",
+        str(Path(__file__).resolve().parent / "migrations"),
+    )
 
     from terminals.config import settings
 

--- a/terminals/config.py
+++ b/terminals/config.py
@@ -1,6 +1,13 @@
 """Application settings loaded from environment variables."""
 
+from pathlib import Path
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Root data directory lives next to the *package* directory so that the
+# location is the same regardless of the caller's working directory.
+_PACKAGE_DIR = Path(__file__).resolve().parent
+_DEFAULT_DATA_DIR = str(_PACKAGE_DIR.parent / "data")
 
 
 class Settings(BaseSettings):
@@ -10,7 +17,7 @@ class Settings(BaseSettings):
     open_webui_url: str = ""  # if set, validate JWTs against this Open WebUI instance
 
     # Database
-    database_url: str = "sqlite+aiosqlite:///./data/terminals.db"
+    database_url: str = f"sqlite+aiosqlite:///{_DEFAULT_DATA_DIR}/terminals.db"
 
     # Backend selection: "docker", "kubernetes", or "kubernetes-operator"
     backend: str = "docker"
@@ -19,7 +26,7 @@ class Settings(BaseSettings):
     image: str = "ghcr.io/open-webui/open-terminal:latest"
     network: str = ""
     docker_host: str = "127.0.0.1"  # address to reach published container ports
-    data_dir: str = "./data/terminals"
+    data_dir: str = f"{_DEFAULT_DATA_DIR}/terminals"
 
     port: int = 3000
     host: str = "0.0.0.0"


### PR DESCRIPTION
## Description

`database_url`, `data_dir`, and `script_location` all used relative paths (`./data/...`, `migrations`), so the server only worked when launched from `terminals/terminals/`. Running `terminals serve` from the repo root or any other directory would silently fail to find migrations or write the DB to an unexpected location. 

Defaults now resolve relative to the package directory so behavior is consistent regardless of CWD.


## Related Issues

N/A

---

## Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](./CLA.md), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
