### PR TITLE
feat: make log level configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ All settings are configured through environment variables prefixed with `TERMINA
 | `TERMINALS_MAX_STORAGE` | | Hard cap on storage per container |
 | `TERMINALS_ALLOWED_IMAGES` | | Comma-separated list of allowed image patterns |
 | `TERMINALS_KUBERNETES_STORAGE_MODE` | `per-user` | `per-user`, `shared`, or `shared-rwo` |
+| `TERMINALS_LOG_LEVEL` | `INFO` | `TRACE`, `DEBUG`, `INFO`, `SUCCESS`, `WARNING`, `ERROR`, or `CRITICAL` |
 
 See [`config.py`](terminals/config.py) for the full list.
 

--- a/operator/handler.py
+++ b/operator/handler.py
@@ -16,6 +16,7 @@ Ported from the ``kubernetes-controller`` branch with the ABC-compatible
 
 import base64
 import logging
+import os
 import secrets
 import string
 from datetime import datetime, timezone
@@ -25,6 +26,25 @@ import kubernetes
 from kubernetes import client as k8s
 
 log = logging.getLogger(__name__)
+
+_VALID_LEVELS = {"TRACE", "DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL"}
+
+
+def _resolve_log_level() -> int:
+    """Read TERMINALS_LOG_LEVEL and translate it to a stdlib logging level."""
+    raw = os.environ.get("TERMINALS_LOG_LEVEL", "INFO").upper()
+    if raw not in _VALID_LEVELS:
+        raw = "INFO"
+    # Loguru's SUCCESS/TRACE have no stdlib equivalents — map to nearest.
+    return {
+        "TRACE": logging.DEBUG,
+        "DEBUG": logging.DEBUG,
+        "INFO": logging.INFO,
+        "SUCCESS": logging.INFO,
+        "WARNING": logging.WARNING,
+        "ERROR": logging.ERROR,
+        "CRITICAL": logging.CRITICAL,
+    }[raw]
 
 GROUP = "openwebui.com"
 VERSION = "v1alpha1"
@@ -43,7 +63,10 @@ def configure(settings: kopf.OperatorSettings, **_):
         kubernetes.config.load_incluster_config()
     except kubernetes.config.ConfigException:
         kubernetes.config.load_kube_config()
-    settings.posting.level = logging.WARNING
+
+    level = _resolve_log_level()
+    logging.getLogger().setLevel(level)
+    settings.posting.level = max(level, logging.WARNING)
     settings.persistence.finalizer = "terminals.openwebui.com/finalizer"
 
 

--- a/terminals/config.py
+++ b/terminals/config.py
@@ -31,6 +31,9 @@ class Settings(BaseSettings):
     port: int = 3000
     host: str = "0.0.0.0"
 
+    # Logging — one of TRACE, DEBUG, INFO, SUCCESS, WARNING, ERROR, CRITICAL
+    log_level: str = "INFO"
+
     # Kubernetes settings
     kubernetes_namespace: str = "terminals"
     kubernetes_image: str = "ghcr.io/open-webui/open-terminal:latest"

--- a/terminals/logging.py
+++ b/terminals/logging.py
@@ -5,6 +5,11 @@ import sys
 
 from loguru import logger
 
+from terminals.config import settings
+
+
+_VALID_LEVELS = {"TRACE", "DEBUG", "INFO", "SUCCESS", "WARNING", "ERROR", "CRITICAL"}
+
 
 class _InterceptHandler(logging.Handler):
     """Route stdlib logging messages into loguru."""
@@ -26,8 +31,24 @@ class _InterceptHandler(logging.Handler):
         )
 
 
+def _resolve_level() -> str:
+    """Resolve and validate the configured log level, falling back to INFO."""
+    level = (settings.log_level or "INFO").upper()
+    if level not in _VALID_LEVELS:
+        logger.warning(
+            "Invalid TERMINALS_LOG_LEVEL={!r}; falling back to INFO. "
+            "Valid levels: {}",
+            settings.log_level,
+            ", ".join(sorted(_VALID_LEVELS)),
+        )
+        return "INFO"
+    return level
+
+
 def setup_logging() -> None:
     """Call once at startup to configure loguru and intercept stdlib logging."""
+
+    level = _resolve_level()
 
     # Remove default loguru handler and add our own.
     logger.remove()
@@ -39,11 +60,13 @@ def setup_logging() -> None:
             "<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - "
             "<level>{message}</level>"
         ),
-        level="DEBUG",
+        level=level,
         colorize=True,
     )
 
-    # Intercept stdlib logging (uvicorn, sqlalchemy, etc.).
+    # Intercept stdlib logging (uvicorn, sqlalchemy, etc.). We forward at
+    # level=0 so loguru — not the stdlib handler — decides what is emitted,
+    # keeping the configured TERMINALS_LOG_LEVEL the single source of truth.
     logging.basicConfig(handlers=[_InterceptHandler()], level=0, force=True)
     for name in ("uvicorn", "uvicorn.error", "uvicorn.access", "sqlalchemy"):
         named = logging.getLogger(name)

--- a/terminals/logging.py
+++ b/terminals/logging.py
@@ -64,9 +64,8 @@ def setup_logging() -> None:
         colorize=True,
     )
 
-    # Intercept stdlib logging (uvicorn, sqlalchemy, etc.). We forward at
-    # level=0 so loguru — not the stdlib handler — decides what is emitted,
-    # keeping the configured TERMINALS_LOG_LEVEL the single source of truth.
+    # Intercept stdlib logging (uvicorn, sqlalchemy, etc.); forward at
+    # level=0 so the loguru sink above owns the level decision.
     logging.basicConfig(handlers=[_InterceptHandler()], level=0, force=True)
     for name in ("uvicorn", "uvicorn.error", "uvicorn.access", "sqlalchemy"):
         named = logging.getLogger(name)


### PR DESCRIPTION
## What

Adds a `TERMINALS_LOG_LEVEL` environment variable to control logging verbosity. Closes #21.

The loguru sink was previously hard-coded to `DEBUG`, which is noisy in production and offered no way to adjust verbosity. This makes the level configurable, defaulting to `INFO`.

## Changes

- **`terminals/config.py`** — new `log_level` setting (`TERMINALS_LOG_LEVEL`, default `INFO`).
- **`terminals/logging.py`** — the loguru sink now uses the configured level. Invalid values fall back to `INFO` with a warning. The `level=0` stdlib intercept is retained intentionally so loguru remains the single arbiter of what gets emitted (uvicorn/sqlalchemy logs included).
- **`operator/handler.py`** — the operator reads the same env var and sets the root stdlib + kopf posting level accordingly. Loguru-only levels (`TRACE`, `SUCCESS`) map to their nearest stdlib equivalents.
- **`README.md`** — documents the new variable.

Accepted values: `TRACE`, `DEBUG`, `INFO`, `SUCCESS`, `WARNING`, `ERROR`, `CRITICAL`.

## Testing

Verified manually that the sink honors the configured level (e.g. `WARNING` suppresses `DEBUG`/`INFO`), and that an invalid value (e.g. `bogus`) falls back to `INFO` with a warning. No automated test suite is present in the repo.