### PR TITLE
fix: best-effort max storage on docker backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ curl -X POST http://localhost:3000/p/data-science/execute \
 | `storage_mode` | string | `per-user`, `shared`, or `shared-rwo` |
 | `idle_timeout_minutes` | int | Minutes of inactivity before the container is cleaned up |
 
+> [!NOTE]
+> **Storage limits are fully enforced only on the Kubernetes backends** (via sized PVCs). On the `docker` backend, `storage` (and `TERMINALS_MAX_STORAGE`) caps the container's *writable layer* via Docker's `StorageOpt`, which requires a storage driver that supports it (e.g. overlay2 on XFS with the `pquota` mount option). On unsupported drivers such as overlay2-on-ext4, Terminals logs a warning and provisions without the limit. The persistent `/home/user` directory is bind-mounted from the host and is **not** quota-limited on Docker. Use a Kubernetes backend if you need hard per-user storage caps.
+
 ## Configuration
 
 All settings are configured through environment variables prefixed with `TERMINALS_`, or via a `.env` file.

--- a/terminals/backends/docker.py
+++ b/terminals/backends/docker.py
@@ -14,7 +14,7 @@ import httpx
 
 from terminals.backends.base import Backend
 from terminals.config import settings
-from terminals.utils.parsing import parse_cpu_nanos, parse_memory
+from terminals.utils.parsing import parse_cpu_nanos, parse_memory, parse_size
 
 log = logging.getLogger(__name__)
 
@@ -73,6 +73,18 @@ class DockerBackend(Backend):
         if s.get("cpu_limit"):
             host_config["NanoCpus"] = parse_cpu_nanos(s["cpu_limit"])
 
+        # Storage caps the container's writable layer via StorageOpt — not the
+        # bind-mounted /home/user where user files persist (Docker can't quota a
+        # bind mount).  It also needs a storage driver that supports it (e.g.
+        # overlay2 on xfs with pquota); on others the create below fails, so the
+        # loop drops the quota and retries.  Use Kubernetes for hard limits.
+        if s.get("storage"):
+            host_config["StorageOpt"] = {"size": str(parse_size(s["storage"]))}
+            log.info(
+                "Applying storage quota %s to writable layer of %s (/home/user not limited)",
+                s["storage"], instance_name,
+            )
+
         # Egress filtering is handled inside the container (dnsmasq + ipset +
         # iptables + capsh) triggered by OPEN_TERMINAL_ALLOWED_DOMAINS env var.
         # Grant CAP_NET_ADMIN so the entrypoint can set up iptables rules
@@ -123,6 +135,19 @@ class DockerBackend(Backend):
                     except aiodocker.exceptions.DockerError:
                         pass
                     await asyncio.sleep(1)
+                    continue
+                # The storage driver may not support StorageOpt size quotas
+                # (e.g. overlay2 on ext4).  Drop the quota and retry once rather
+                # than failing to provision.  host_config is the same object
+                # referenced by config["HostConfig"], so this mutation applies
+                # to the next create attempt.
+                if "StorageOpt" in host_config:
+                    log.warning(
+                        "Storage quota not supported by the Docker storage driver "
+                        "for %s (%s), provisioning without a storage limit",
+                        instance_name, exc,
+                    )
+                    host_config.pop("StorageOpt", None)
                     continue
                 log.error("Failed to provision container for %s: %s", user_id, exc)
                 raise


### PR DESCRIPTION
## Description

The `docker` backend silently ignored the `storage` field. `provision()` wired up `image`, `memory_limit`, `cpu_limit`, and `env`, but never read `storage` — so per-policy `storage` and `TERMINALS_MAX_STORAGE` had no effect on Docker (Kubernetes already sized PVCs correctly).

This wires `storage` into the container via Docker's `StorageOpt`, capping the writable layer. Because not every storage driver supports quotas (e.g. overlay2-on-ext4), provisioning falls back gracefully. If the daemon rejects the quota, it logs a warning and retries without it instead of failing.

Caveat documented in the README: `StorageOpt` limits only the container's writable layer, not the bind-mounted `/home/user` where user files persist (Docker can't quota a bind mount). For hard per-user storage caps, use a Kubernetes backend.

- `terminals/backends/docker.py` — apply `StorageOpt` from `storage`, with retry-without-quota fallback
- `README.md` — note on Docker storage-limit behavior and its limits

Verified end-to-end against a live Docker daemon: quota applied (`StorageOpt={'size': ...}` confirmed via inspect), absent when unset, and fallback retries cleanly on rejection.

## Related Issues

Fixes #23

---

## Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](./CLA.md), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
