### PR TITLE
Add Kubernetes scheduling overrides for terminal pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ All settings are configured through environment variables prefixed with `TERMINA
 | `TERMINALS_ALLOWED_IMAGES` | | Comma-separated list of allowed image patterns |
 | `TERMINALS_KUBERNETES_STORAGE_MODE` | `per-user` | `per-user`, `shared`, or `shared-rwo` |
 | `TERMINALS_KUBERNETES_RESTRICTED` | `false` | Enable restricted Kubernetes/OpenShift pod defaults globally |
+| `TERMINALS_KUBERNETES_NODE_SELECTOR` | | JSON object of node labels to apply as `nodeSelector` on Kubernetes terminal pods, e.g. `{"node-pool":"terminals"}` |
+| `TERMINALS_KUBERNETES_TOLERATIONS` | | JSON array of Kubernetes tolerations to apply to Kubernetes terminal pods |
 | `TERMINALS_KUBERNETES_POD_SECURITY_CONTEXT` | | JSON pod security context merged into Kubernetes terminal pods |
 | `TERMINALS_KUBERNETES_CONTAINER_SECURITY_CONTEXT` | | JSON container security context merged into Kubernetes terminal containers |
 | `TERMINALS_DATABASE_URL` | `sqlite+aiosqlite:///.../data/terminals.db` | SQLAlchemy database URL. SQLite is the default; PostgreSQL is optional. |

--- a/operator/handler.py
+++ b/operator/handler.py
@@ -15,6 +15,7 @@ Ported from the ``kubernetes-controller`` branch with the ABC-compatible
 """
 
 import base64
+import json
 import logging
 import os
 import re
@@ -100,6 +101,29 @@ def _resource_name(name: str, suffix: str) -> str:
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _json_env(name: str, default):
+    raw = os.environ.get(name, "")
+    if not raw:
+        return default
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        log.warning("Ignoring invalid JSON in %s", name)
+        return default
+    return value
+
+
+def _pod_scheduling_overrides() -> dict:
+    overrides = {}
+    node_selector = _json_env("TERMINALS_KUBERNETES_NODE_SELECTOR", {})
+    tolerations = _json_env("TERMINALS_KUBERNETES_TOLERATIONS", [])
+    if isinstance(node_selector, dict) and node_selector:
+        overrides["nodeSelector"] = {str(k): str(v) for k, v in node_selector.items()}
+    if isinstance(tolerations, list) and tolerations:
+        overrides["tolerations"] = tolerations
+    return overrides
 
 
 _SIZE_RE = re.compile(r"^(\d+(?:\.\d+)?)\s*(Ki|Mi|Gi|Ti)?$")
@@ -318,6 +342,7 @@ def _build_pod_manifest(
         "enableServiceLinks": False,
         "automountServiceAccountToken": False,
     }
+    pod_spec.update(_pod_scheduling_overrides())
     pod_security_context = _deep_merge(
         RESTRICTED_POD_SECURITY_CONTEXT if restricted else {},
         spec.get("podSecurityContext"),

--- a/terminals/backends/kubernetes_operator.py
+++ b/terminals/backends/kubernetes_operator.py
@@ -11,7 +11,9 @@ This backend reads the key from the Secret referenced in ``status.apiKeySecret``
 import asyncio
 import base64
 import hashlib
+import json
 import logging
+import os
 import re
 from typing import Optional
 
@@ -43,6 +45,28 @@ def _sanitize_name(user_id: str, policy_id: str = "default") -> str:
         return f"terminal-{short}"
     policy_slug = _DNS_SAFE.sub("-", policy_id.lower()).strip("-")[:20]
     return f"terminal-{short}-{policy_slug}"
+
+
+def _json_env(name: str, default):
+    raw = os.environ.get(name, "")
+    if not raw:
+        return default
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        log.warning("Ignoring invalid JSON in %s", name)
+        return default
+
+
+def _pod_scheduling_overrides() -> dict:
+    overrides = {}
+    node_selector = _json_env("TERMINALS_KUBERNETES_NODE_SELECTOR", {})
+    tolerations = _json_env("TERMINALS_KUBERNETES_TOLERATIONS", [])
+    if isinstance(node_selector, dict) and node_selector:
+        overrides["node_selector"] = {str(k): str(v) for k, v in node_selector.items()}
+    if isinstance(tolerations, list) and tolerations:
+        overrides["tolerations"] = tolerations
+    return overrides
 
 
 class KubernetesOperatorBackend(Backend):
@@ -449,6 +473,7 @@ class KubernetesOperatorBackend(Backend):
             metadata=client.V1ObjectMeta(name=reset_name, namespace=ns, labels=labels),
             spec=client.V1PodSpec(
                 restart_policy="Never",
+                **_pod_scheduling_overrides(),
                 containers=[
                     client.V1Container(
                         name="reset",


### PR DESCRIPTION
## Summary

Adds optional Kubernetes scheduling overrides for the `kubernetes-operator` backend.

This allows cluster operators to configure generated terminal pods and reset pods with:

- `TERMINALS_KUBERNETES_NODE_SELECTOR`
- `TERMINALS_KUBERNETES_TOLERATIONS`

Both values are JSON-encoded environment variables. If unset, behavior is unchanged.

## Problem

The Kubernetes operator backend currently supports per-terminal images, resources, environment, persistence, and storage class selection, but it does not expose a way for cluster operators to constrain where generated terminal pods run.

For multi-tenant or resource-isolated deployments, operators may need terminal pods to run only on a dedicated node pool. A common example is isolating user terminal workloads from stateful platform services by using Kubernetes node labels and taints.

Without this, generated terminal pods can schedule onto any eligible cluster node.

## Solution

This PR adds a small, opt-in scheduling override path:

- The operator reads `TERMINALS_KUBERNETES_NODE_SELECTOR` and applies it to generated terminal pod specs as `nodeSelector`.
- The operator reads `TERMINALS_KUBERNETES_TOLERATIONS` and applies it to generated terminal pod specs as `tolerations`.
- The Terminals service reads the same values and applies them to generated reset pods.

Invalid JSON is ignored with a warning, preserving existing behavior.

## Example

```bash
TERMINALS_KUBERNETES_NODE_SELECTOR='{"example.com/node-pool":"terminals"}'
TERMINALS_KUBERNETES_TOLERATIONS='[{"key":"example.com/node-pool","operator":"Equal","value":"terminals","effect":"NoSchedule"}]'
```

## Compatibility
This is backwards compatible. If the environment variables are not set, generated pod specs are unchanged.

## Testing
- Verified the patch applies cleanly.
- Intended deployment target is a Kubernetes cluster using a tainted dedicated node pool for terminal workloads.
- Manual cluster validation plan:
  - create a terminal
  - confirm generated terminal pod has the expected nodeSelector
  - confirm generated terminal pod has the expected tolerations
  - confirm pod schedules only on the intended node pool
  - confirm reset pod uses the same scheduling overrides