### PR TITLE
Fix wheel packaging to include the built admin UI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,9 @@ include = [
     "terminals/migrations/**/*",
     "terminals/frontend/build/**/*",
 ]
+# The frontend build output is gitignored, and hatchling excludes
+# VCS-ignored files even when they match `include`. `artifacts` is the
+# override that actually ships them in the wheel.
+artifacts = [
+    "terminals/frontend/build/**/*",
+]


### PR DESCRIPTION
The frontend build output (terminals/frontend/build/) is gitignored via the root .gitignore ("build/") and terminals/frontend/.gitignore ("build"). Hatchling honors VCS ignore files during file selection and excludes gitignored paths even when they match an `include` pattern, so every wheel built by `pip install .` — including the one inside the Docker image — silently shipped without the UI.

At runtime the installed package therefore has no frontend/build directory, main.py never registers the "/" route, and browser requests fall through to the authenticated catch-all proxy, returning 401 {"detail":"Missing Authorization header"} instead of the admin UI.

Declare the build output under hatchling's `artifacts` option, which is the documented override for shipping VCS-ignored build outputs.

## Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](./CLA.md), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
