### PR TITLE
PERF/FIX: Reduce orchestrator CPU at high session counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ All settings are configured through environment variables prefixed with `TERMINA
 | `TERMINALS_KUBERNETES_TOLERATIONS` | | JSON array of Kubernetes tolerations for terminal and reset pods |
 | `TERMINALS_DATABASE_URL` | `sqlite+aiosqlite:///.../data/terminals.db` | SQLAlchemy database URL. SQLite is the default; PostgreSQL is optional. |
 | `TERMINALS_LOG_LEVEL` | `INFO` | Minimum log level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL` |
+| `TERMINALS_STATUS_CACHE_TTL` | `30` | Seconds a confirmed-running container status is trusted before re-inspecting it via the backend. `0` re-checks on every request. The cache is invalidated immediately when a proxied connection fails. |
+| `TERMINALS_WS_COMPRESSION` | `false` | Enable permessage-deflate on proxied WebSocket terminal traffic. Leave off unless clients connect over slow links — per-frame compression is CPU-expensive at high session counts. |
+| `TERMINALS_ACCESS_LOG` | `false` | Log every HTTP request. Off by default: at high request rates the per-request log record is measurable CPU. |
+| `TERMINALS_TOKEN_CACHE_TTL` | `60` | Seconds a successfully validated Open WebUI token is cached (JWT mode only), avoiding one Open WebUI round trip per proxied request. A revoked token stays usable for up to the TTL; `0` validates every request. |
 
 See [`config.py`](terminals/config.py) for the full list.
 

--- a/dev.sh
+++ b/dev.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-uv run uvicorn terminals.main:app --reload
+uv run uvicorn terminals.main:app --reload --ws-per-message-deflate false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,9 @@ include = [
     "terminals/migrations/**/*",
     "terminals/frontend/build/**/*",
 ]
+# .gitignore contains "build/", and hatchling excludes VCS-ignored files even
+# when they match `include`. Ignored build outputs must be listed as artifacts,
+# otherwise wheels (and the Docker image) ship without the admin UI.
+artifacts = [
+    "terminals/frontend/build",
+]

--- a/terminals/backends/base.py
+++ b/terminals/backends/base.py
@@ -38,6 +38,7 @@ class Backend(ABC):
         self._instances: dict[str, dict] = {}       # → provision result dict
         self._specs: dict[str, dict] = {}           # → resolved policy spec
         self._locks: dict[str, asyncio.Lock] = {}   # → per-key provisioning lock
+        self._status_ok_at: dict[str, float] = {}   # → last confirmed-running check
         self._reaper_task: Optional[asyncio.Task] = None
 
     # ------------------------------------------------------------------
@@ -95,6 +96,29 @@ class Backend(ABC):
         self._activity[key] = time.monotonic()
         self._activity_wall[key] = time.time()
 
+    # ------------------------------------------------------------------
+    # Status cache — avoid re-inspecting the container on every request
+    # ------------------------------------------------------------------
+
+    def _status_fresh(self, key: str) -> bool:
+        ttl = settings.status_cache_ttl
+        if ttl <= 0:
+            return False
+        checked = self._status_ok_at.get(key)
+        return checked is not None and (time.monotonic() - checked) < ttl
+
+    def _mark_status_ok(self, key: str) -> None:
+        self._status_ok_at[key] = time.monotonic()
+
+    def invalidate_status(self, user_id: str, policy_id: str = "default") -> None:
+        """Force the next request for this key to re-verify instance status.
+
+        Called by the proxy when it fails to connect to an instance that
+        was assumed running — the re-check detects a dead container and
+        re-provisions it.
+        """
+        self._status_ok_at.pop(self._key(user_id, policy_id), None)
+
     async def ensure_terminal(
         self,
         user_id: str,
@@ -114,8 +138,15 @@ class Backend(ABC):
         # Fast path — already tracked and running.
         if key in self._instances:
             info = self._instances[key]
+            # Skip the backend status inspection while the last confirmed
+            # check is fresh — at hundreds of users this is the difference
+            # between pure dict lookups and 2 Docker API calls per request.
+            if self._status_fresh(key):
+                self._record_activity(key)
+                return info
             st = await self.status(info["instance_id"])
             if st == "running":
+                self._mark_status_ok(key)
                 self._record_activity(key)
                 return info
 
@@ -130,18 +161,21 @@ class Backend(ABC):
                 info = self._instances[key]
                 st = await self.status(info["instance_id"])
                 if st == "running":
+                    self._mark_status_ok(key)
                     self._record_activity(key)
                     return info
                 self._instances.pop(key, None)
                 self._specs.pop(key, None)
                 self._activity.pop(key, None)
                 self._activity_wall.pop(key, None)
+                self._status_ok_at.pop(key, None)
 
             await self._apply_due_reset(user_id, policy_id, spec)
             result = await self.provision(user_id, policy_id=policy_id, spec=spec)
             if result:
                 self._instances[key] = result
                 self._specs[key] = spec or {}
+                self._mark_status_ok(key)
                 self._record_activity(key)
             return result
 
@@ -218,6 +252,7 @@ class Backend(ABC):
             self._specs.pop(key, None)
             self._activity.pop(key, None)
             self._activity_wall.pop(key, None)
+            self._status_ok_at.pop(key, None)
             self._locks.pop(key, None)
             result.refreshed += 1
 
@@ -337,4 +372,5 @@ class Backend(ABC):
                 self._specs.pop(key, None)
                 self._activity.pop(key, None)
                 self._activity_wall.pop(key, None)
+                self._status_ok_at.pop(key, None)
                 self._locks.pop(key, None)

--- a/terminals/cli.py
+++ b/terminals/cli.py
@@ -62,6 +62,10 @@ def serve(host: str | None, port: int | None, api_key: str | None):
         host=effective_host,
         port=effective_port,
         log_level=normalize_log_level(settings.log_level).lower(),
+        # Terminal streams re-compressed per frame in pure Python are a major
+        # CPU cost at scale — only enable when explicitly configured.
+        ws_per_message_deflate=settings.ws_compression,
+        access_log=settings.access_log,
     )
 
 

--- a/terminals/config.py
+++ b/terminals/config.py
@@ -35,6 +35,16 @@ class Settings(BaseSettings):
     log_level: str = "INFO"  # DEBUG, INFO, WARNING, ERROR, CRITICAL
     enable_ui: bool = True
 
+    # Proxy performance
+    status_cache_ttl: int = 30      # seconds a confirmed-running status is trusted
+                                    # before re-inspecting the container (0 = every request)
+    ws_compression: bool = False    # permessage-deflate on proxied WebSocket traffic
+                                    # (CPU-heavy per frame; leave off for LAN deployments)
+    access_log: bool = False        # per-request access logging (frame-walking log
+                                    # record per request — measurable CPU at scale)
+    token_cache_ttl: int = 60       # seconds a validated Open WebUI token is cached
+                                    # (JWT mode only; 0 = validate every request)
+
     # Kubernetes settings
     kubernetes_namespace: str = "terminals"
     kubernetes_image: str = "ghcr.io/open-webui/open-terminal:latest"

--- a/terminals/middleware.py
+++ b/terminals/middleware.py
@@ -2,24 +2,41 @@
 
 import uuid
 
-from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
-from starlette.requests import Request
-from starlette.responses import Response
 
-
-class RequestIdMiddleware(BaseHTTPMiddleware):
+class RequestIdMiddleware:
     """Attach a unique ``request_id`` to every request.
 
     The ID is stored in ``request.state.request_id`` for downstream use
     and returned as an ``X-Request-Id`` response header.
+
+    Implemented as pure ASGI: Starlette's ``BaseHTTPMiddleware`` wraps every
+    request in extra task machinery, which is measurable overhead on the
+    proxy hot path.
     """
 
-    async def dispatch(
-        self, request: Request, call_next: RequestResponseEndpoint
-    ) -> Response:
-        request_id = request.headers.get("X-Request-Id") or str(uuid.uuid4())
-        request.state.request_id = request_id
+    def __init__(self, app):
+        self.app = app
 
-        response = await call_next(request)
-        response.headers["X-Request-Id"] = request_id
-        return response
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        request_id = ""
+        for key, value in scope.get("headers") or []:
+            if key == b"x-request-id":
+                request_id = value.decode("latin-1")
+                break
+        if not request_id:
+            request_id = str(uuid.uuid4())
+
+        scope.setdefault("state", {})["request_id"] = request_id
+        request_id_bytes = request_id.encode("latin-1")
+
+        async def send_with_header(message):
+            if message["type"] == "http.response.start":
+                headers = message.setdefault("headers", [])
+                headers.append((b"x-request-id", request_id_bytes))
+            await send(message)
+
+        await self.app(scope, receive, send_with_header)

--- a/terminals/routers/auth.py
+++ b/terminals/routers/auth.py
@@ -1,5 +1,7 @@
 """Authentication dependencies for the proxy and API routes."""
 
+import hashlib
+import time
 from typing import Optional
 
 import httpx
@@ -8,6 +10,11 @@ from fastapi import Depends, Header, HTTPException
 from terminals.config import settings
 
 _owui_client: Optional[httpx.AsyncClient] = None
+
+# Cache of successfully validated tokens: sha256(token) → (expires_at, user_id).
+# Without it, every proxied request pays an HTTP round trip to Open WebUI.
+_token_cache: dict[str, tuple[float, str]] = {}
+_TOKEN_CACHE_MAX_ENTRIES = 10000
 
 
 async def _get_owui_client() -> httpx.AsyncClient:
@@ -30,8 +37,19 @@ async def validate_token(token: str) -> Optional[str]:
     Returns the verified user ID on success.
     Raises ``HTTPException`` on failure.
 
+    Successful validations are cached for ``settings.token_cache_ttl``
+    seconds (0 disables caching); failures are never cached. The trade-off:
+    a token revoked in Open WebUI stays usable here for up to the TTL.
+
     Only call when ``settings.open_webui_url`` is set.
     """
+    ttl = settings.token_cache_ttl
+    key = hashlib.sha256(token.encode()).hexdigest() if ttl > 0 else ""
+    if key:
+        cached = _token_cache.get(key)
+        if cached and cached[0] > time.monotonic():
+            return cached[1]
+
     client = await _get_owui_client()
     url = settings.open_webui_url.rstrip("/")
     try:
@@ -48,6 +66,17 @@ async def validate_token(token: str) -> Optional[str]:
     verified_user_id = data.get("id")
     if not verified_user_id:
         raise HTTPException(status_code=401, detail="Token response missing user ID")
+
+    if key:
+        now = time.monotonic()
+        if len(_token_cache) >= _TOKEN_CACHE_MAX_ENTRIES:
+            # Drop expired entries; if everything is live, reset outright
+            # rather than growing without bound.
+            live = {k: v for k, v in _token_cache.items() if v[0] > now}
+            _token_cache.clear()
+            if len(live) < _TOKEN_CACHE_MAX_ENTRIES:
+                _token_cache.update(live)
+        _token_cache[key] = (now + ttl, verified_user_id)
     return verified_user_id
 
 

--- a/terminals/routers/proxy.py
+++ b/terminals/routers/proxy.py
@@ -31,27 +31,55 @@ router = APIRouter()
 # Proxy client
 # ---------------------------------------------------------------------------
 
-_proxy_client: Optional[httpx.AsyncClient] = None
+# One small client per upstream origin (host, port). httpcore scans a
+# client's ENTIRE connection pool — including a readability syscall per idle
+# keepalive connection — on every request event, so a single shared pool
+# over hundreds of distinct terminal containers spends most of the event
+# loop in pool management (observed ~69% of CPU under py-spy at ~600
+# containers). Per-origin pools keep each scan at a handful of connections.
+_proxy_clients: dict[tuple[str, int], httpx.AsyncClient] = {}
+_PROXY_CLIENTS_MAX = 1200  # LRU-evict beyond this many distinct origins
+_client_close_tasks: set = set()
 
 # Active WebSocket connection counter (for stats endpoint)
 active_ws_connections: int = 0
 
 
-async def _get_proxy_client() -> httpx.AsyncClient:
-    global _proxy_client
-    if _proxy_client is None:
-        _proxy_client = httpx.AsyncClient(
+async def _get_proxy_client(host: str, port: int) -> httpx.AsyncClient:
+    key = (host, port)
+    # dict preserves insertion order — pop + reinsert keeps it LRU-ordered.
+    client = _proxy_clients.pop(key, None)
+    if client is None:
+        client = httpx.AsyncClient(
             timeout=httpx.Timeout(300.0, connect=10.0),
-            limits=httpx.Limits(keepalive_expiry=4.0),
+            limits=httpx.Limits(
+                max_connections=32,
+                max_keepalive_connections=4,
+                keepalive_expiry=30.0,
+            ),
         )
-    return _proxy_client
+    _proxy_clients[key] = client
+
+    # Evict the least-recently-used origin (stale after container teardown /
+    # port change) so held sockets don't accumulate forever.
+    if len(_proxy_clients) > _PROXY_CLIENTS_MAX:
+        old_key = next(iter(_proxy_clients))
+        old_client = _proxy_clients.pop(old_key)
+        task = asyncio.get_running_loop().create_task(old_client.aclose())
+        _client_close_tasks.add(task)
+        task.add_done_callback(_client_close_tasks.discard)
+
+    return client
 
 
 async def close_proxy_client() -> None:
-    global _proxy_client
-    if _proxy_client is not None:
-        await _proxy_client.aclose()
-        _proxy_client = None
+    clients = list(_proxy_clients.values())
+    _proxy_clients.clear()
+    for client in clients:
+        try:
+            await client.aclose()
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -131,13 +159,18 @@ async def _proxy_request(
     Streams both the request body (upload) and response body (download)
     to avoid buffering large payloads in memory.
     """
+    backend = request.app.state.backend
     instance = await _resolve_instance(
         request, user_id, policy_id=policy_id, spec=spec,
     )
 
-    target_url = f"http://{instance.host}:{instance.port}/{path}"
-    if request.query_params:
-        target_url += f"?{request.query_params}"
+    def _target_url(inst: InstanceInfo) -> str:
+        url = f"http://{inst.host}:{inst.port}/{path}"
+        if request.query_params:
+            url += f"?{request.query_params}"
+        return url
+
+    target_url = _target_url(instance)
 
     headers = dict(request.headers)
     # Replace auth with the instance's own API key.
@@ -149,7 +182,7 @@ async def _proxy_request(
     # Read the request body upfront (needed for retries).
     body = await request.body()
 
-    client = await _get_proxy_client()
+    client = await _get_proxy_client(instance.host, instance.port)
 
     # Retry on connection errors — the container may still be starting.
     max_retries = 5
@@ -166,9 +199,27 @@ async def _proxy_request(
             )
             break
         except (httpx.ConnectError, httpx.ConnectTimeout) as e:
+            # The tracked instance isn't reachable — stop trusting the cached
+            # status and re-resolve. ensure_terminal re-checks the container
+            # and re-provisions if it died, healing mid-request.
+            backend.invalidate_status(user_id, policy_id)
             if attempt < max_retries - 1:
                 logger.debug("Proxy attempt {} to {} failed ({}), retrying...", attempt + 1, target_url, e)
                 await asyncio.sleep(1)
+                try:
+                    instance = await _resolve_instance(
+                        request, user_id, policy_id=policy_id, spec=spec,
+                    )
+                except Exception as resolve_err:
+                    logger.error("Re-resolving terminal for user {} failed: {}", user_id, resolve_err)
+                    return Response(
+                        content='{"error": "Terminal instance not reachable"}',
+                        status_code=502,
+                        media_type="application/json",
+                    )
+                target_url = _target_url(instance)
+                headers["authorization"] = f"Bearer {instance.api_key}"
+                client = await _get_proxy_client(instance.host, instance.port)
             else:
                 logger.error("Proxy request to {} failed after {} retries: {}", target_url, max_retries, e)
                 return Response(
@@ -177,6 +228,9 @@ async def _proxy_request(
                     media_type="application/json",
                 )
         except (httpx.RemoteProtocolError, httpx.ReadError) as e:
+            # Could be a stale pooled connection, or the container died
+            # mid-request — re-verify its status on the next resolve.
+            backend.invalidate_status(user_id, policy_id)
             if attempt < max_retries - 1:
                 logger.debug(
                     "Proxy attempt {} to {} hit a stale upstream connection ({}), retrying...",
@@ -225,7 +279,7 @@ async def _fetch_spec_with_retry(instance: InstanceInfo) -> dict:
     Newly provisioned containers may need a few seconds to start serving.
     This retries with a short delay to avoid returning 502 on first access.
     """
-    client = await _get_proxy_client()
+    client = await _get_proxy_client(instance.host, instance.port)
     url = f"http://{instance.host}:{instance.port}/openapi.json"
     headers = {"Authorization": f"Bearer {instance.api_key}"}
 
@@ -282,7 +336,13 @@ async def _get_cached_spec(
     instance = await _resolve_instance(
         request, _SYSTEM_USER_ID, policy_id=policy_id, spec=spec,
     )
-    raw = await _fetch_spec_with_retry(instance)
+    try:
+        raw = await _fetch_spec_with_retry(instance)
+    except Exception:
+        # The system instance may be gone — re-verify it on the next attempt
+        # instead of trusting the cached status for the full TTL.
+        request.app.state.backend.invalidate_status(_SYSTEM_USER_ID, policy_id)
+        raise
     stripped = _strip_auth_from_spec(raw)
     _spec_cache[policy_id] = (now, stripped)
     return stripped
@@ -477,7 +537,24 @@ async def _ws_proxy_handler(
     """Core WebSocket proxy logic, shared by default and policy routes."""
     global active_ws_connections
     active_ws_connections += 1
+    try:
+        await _ws_proxy(ws, session_id, user_id, policy_id=policy_id, spec=spec)
+    finally:
+        active_ws_connections -= 1
+        try:
+            await ws.close()
+        except Exception:
+            pass
 
+
+async def _ws_proxy(
+    ws: WebSocket,
+    session_id: str,
+    user_id: str,
+    policy_id: str = "default",
+    spec: Optional[dict] = None,
+):
+    backend = ws.app.state.backend
     try:
         instance = await _resolve_instance(
             ws, user_id, policy_id=policy_id, spec=spec
@@ -487,19 +564,40 @@ async def _ws_proxy_handler(
         await ws.close(code=4003, reason="Failed to resolve terminal instance")
         return
 
-    upstream_url = f"ws://{instance.host}:{instance.port}/api/terminals/{session_id}"
-
     # Retry WebSocket connection — the container may still be starting.
+    # permessage-deflate is disabled by default: compressing every terminal
+    # frame in pure Python burns significant CPU at scale for traffic that
+    # normally stays on the local host / LAN.
+    ws_compression = "deflate" if settings.ws_compression else None
     max_retries = 5
     upstream = None
     for attempt in range(max_retries):
+        upstream_url = f"ws://{instance.host}:{instance.port}/api/terminals/{session_id}"
         try:
-            upstream = await websockets.connect(upstream_url)
+            upstream = await websockets.connect(
+                upstream_url, compression=ws_compression
+            )
             break
-        except (ConnectionRefusedError, OSError) as e:
+        except (
+            ConnectionRefusedError,
+            OSError,
+            websockets.exceptions.InvalidHandshake,
+        ) as e:
+            # Unreachable (or answering but not upgrading yet) — stop
+            # trusting the cached status and re-resolve, so a container
+            # that died gets re-provisioned mid-connect.
+            backend.invalidate_status(user_id, policy_id)
             if attempt < max_retries - 1:
                 logger.debug("WS connect attempt {} to {} failed ({}), retrying...", attempt + 1, upstream_url, e)
                 await asyncio.sleep(1)
+                try:
+                    instance = await _resolve_instance(
+                        ws, user_id, policy_id=policy_id, spec=spec
+                    )
+                except Exception as resolve_err:
+                    logger.error("WS re-resolve for user {} failed: {}", user_id, resolve_err)
+                    await ws.close(code=4003, reason="Terminal instance not reachable")
+                    return
             else:
                 logger.error("WS connect to {} failed after {} retries: {}", upstream_url, max_retries, e)
                 await ws.close(code=4003, reason="Terminal instance not reachable")
@@ -539,12 +637,6 @@ async def _ws_proxy_handler(
             )
     except Exception as e:
         logger.error("WebSocket terminal proxy error: {}", e)
-    finally:
-        active_ws_connections -= 1
-        try:
-            await ws.close()
-        except Exception:
-            pass
 
 
 @router.websocket("/api/terminals/{session_id}")


### PR DESCRIPTION
## Description

At ~500-600 concurrent terminals, the orchestrator process is permanently pinned
at 100% of one CPU core (it's a single asyncio process). We profiled a production
deployment with py-spy and eliminated the hot spots; the same load now runs at
~32% of one core (GIL contention dropped from 92% to 24%).

**Performance changes:**
- One small HTTP client per upstream `(host, port)` instead of a single shared
  connection pool. httpcore scans the entire pool on every request event, with a
  readability syscall per idle keepalive connection — with hundreds of distinct
  container origins in one pool this alone consumed ~69% of the event loop.
  Stale origins are LRU-evicted and their sockets closed.
- WebSocket permessage-deflate disabled by default on both proxy legs
  (`TERMINALS_WS_COMPRESSION` re-enables). Compressing every terminal frame in
  pure Python is a large per-frame cost for traffic that rarely leaves the host.
- Confirmed-running container status is cached for `TERMINALS_STATUS_CACHE_TTL`
  seconds (default 30, `0` restores check-every-request), removing two Docker
  inspects + JSON parsing per proxied request. On connection failure the proxy
  invalidates the cache and re-resolves mid-request, so a dead container is
  re-provisioned on retry instead of returning 502.
- Successful Open WebUI token validations cached for `TERMINALS_TOKEN_CACHE_TTL`
  seconds (default 60, `0` disables) in JWT mode — previously one Open WebUI
  round trip per proxied request. Note: a revoked token stays usable up to TTL.
- Access logging is now opt-in (`TERMINALS_ACCESS_LOG`); each record walks the
  stack in the loguru intercept handler. Maintainers may prefer default `true` —
  happy to flip.
- `RequestIdMiddleware` rewritten as pure ASGI (`BaseHTTPMiddleware` adds
  per-request task overhead).

**Bug fixes found along the way:**
- `active_ws_connections` leaked on failed connect attempts (early returns
  skipped the decrement).
- WS upgrade failures (`InvalidHandshake`, e.g. container still initializing)
  escaped the retry loop as unhandled exceptions.
- Wheels shipped without the admin UI: `.gitignore` contains `build/` and
  hatchling excludes VCS-ignored files even when they match `include` patterns,
  so `terminals/frontend/build` was missing from `pip install .` and `GET /`
  returned 401 in Docker images. Fixed by declaring it via `artifacts`.

## Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](./CLA.md), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
