### PR TITLE
Fix WebSocket connection counter leak and guard mid-retry re-resolves

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ All settings are configured through environment variables prefixed with `TERMINA
 | `TERMINALS_KUBERNETES_TOLERATIONS` | | JSON array of Kubernetes tolerations for terminal and reset pods |
 | `TERMINALS_DATABASE_URL` | `sqlite+aiosqlite:///.../data/terminals.db` | SQLAlchemy database URL. SQLite is the default; PostgreSQL is optional. |
 | `TERMINALS_LOG_LEVEL` | `INFO` | Minimum log level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL` |
+| `TERMINALS_STATUS_CACHE_TTL` | `30` | Seconds a confirmed-running container status is trusted before re-inspecting it via the backend. `0` re-checks on every request. The cache is invalidated immediately when a proxied connection fails. |
+| `TERMINALS_TOKEN_CACHE_TTL` | `60` | Seconds a successfully validated Open WebUI token is cached (JWT mode only), avoiding one Open WebUI round trip per proxied request. A revoked token stays usable for up to the TTL; `0` validates every request. |
+| `TERMINALS_WS_COMPRESSION` | `false` | Enable permessage-deflate on proxied WebSocket terminal traffic. Leave off unless clients connect over slow links — per-frame compression is CPU-expensive at high session counts. |
+| `TERMINALS_ACCESS_LOG` | `false` | Log every HTTP request. Off by default: at high request rates the per-request log record is measurable CPU. |
 
 See [`config.py`](terminals/config.py) for the full list.
 

--- a/terminals/routers/proxy.py
+++ b/terminals/routers/proxy.py
@@ -178,9 +178,17 @@ async def _proxy_request(
             if attempt < max_retries - 1:
                 logger.debug("Proxy attempt {} to {} failed ({}), retrying...", attempt + 1, target_url, e)
                 await asyncio.sleep(1)
-                instance = await _resolve_instance(
-                    request, user_id, policy_id=policy_id, spec=spec
-                )
+                try:
+                    instance = await _resolve_instance(
+                        request, user_id, policy_id=policy_id, spec=spec
+                    )
+                except Exception as resolve_err:
+                    logger.error("Re-resolving terminal for user {} failed: {}", user_id, resolve_err)
+                    return Response(
+                        content='{"error": "Terminal instance not reachable"}',
+                        status_code=502,
+                        media_type="application/json",
+                    )
                 target_url = f"http://{instance.host}:{instance.port}/{path}"
                 if request.query_params:
                     target_url += f"?{request.query_params}"
@@ -202,9 +210,17 @@ async def _proxy_request(
                     target_url,
                     e,
                 )
-                instance = await _resolve_instance(
-                    request, user_id, policy_id=policy_id, spec=spec
-                )
+                try:
+                    instance = await _resolve_instance(
+                        request, user_id, policy_id=policy_id, spec=spec
+                    )
+                except Exception as resolve_err:
+                    logger.error("Re-resolving terminal for user {} failed: {}", user_id, resolve_err)
+                    return Response(
+                        content='{"error": "Upstream connection failed"}',
+                        status_code=502,
+                        media_type="application/json",
+                    )
                 target_url = f"http://{instance.host}:{instance.port}/{path}"
                 if request.query_params:
                     target_url += f"?{request.query_params}"
@@ -510,10 +526,31 @@ async def _ws_proxy_handler(
     policy_id: str = "default",
     spec: Optional[dict] = None,
 ):
-    """Core WebSocket proxy logic, shared by default and policy routes."""
+    """Core WebSocket proxy logic, shared by default and policy routes.
+
+    The connection counter is maintained here with a try/finally around the
+    whole proxy body — early returns on resolve/connect failures previously
+    skipped the decrement, inflating the counter permanently.
+    """
     global active_ws_connections
     active_ws_connections += 1
+    try:
+        await _ws_proxy(ws, session_id, user_id, policy_id=policy_id, spec=spec)
+    finally:
+        active_ws_connections -= 1
+        try:
+            await ws.close()
+        except Exception:
+            pass
 
+
+async def _ws_proxy(
+    ws: WebSocket,
+    session_id: str,
+    user_id: str,
+    policy_id: str = "default",
+    spec: Optional[dict] = None,
+):
     try:
         instance = await _resolve_instance(
             ws, user_id, policy_id=policy_id, spec=spec
@@ -543,9 +580,14 @@ async def _ws_proxy_handler(
             if attempt < max_retries - 1:
                 logger.debug("WS connect attempt {} to {} failed ({}), retrying...", attempt + 1, upstream_url, e)
                 await asyncio.sleep(1)
-                instance = await _resolve_instance(
-                    ws, user_id, policy_id=policy_id, spec=spec
-                )
+                try:
+                    instance = await _resolve_instance(
+                        ws, user_id, policy_id=policy_id, spec=spec
+                    )
+                except Exception as resolve_err:
+                    logger.error("WS re-resolve for user {} failed: {}", user_id, resolve_err)
+                    await ws.close(code=4003, reason="Terminal instance not reachable")
+                    return
             else:
                 logger.error("WS connect to {} failed after {} retries: {}", upstream_url, max_retries, e)
                 await ws.close(code=4003, reason="Terminal instance not reachable")
@@ -585,12 +627,6 @@ async def _ws_proxy_handler(
             )
     except Exception as e:
         logger.error("WebSocket terminal proxy error: {}", e)
-    finally:
-        active_ws_connections -= 1
-        try:
-            await ws.close()
-        except Exception:
-            pass
 
 
 @router.websocket("/api/terminals/{session_id}")


### PR DESCRIPTION
## Description

Follow-up to c9be162 (orchestrator performance work):

- **Fix `active_ws_connections` leaking on failed connection attempts.** The
  counter is incremented on entry to `_ws_proxy_handler` but was only
  decremented in the `finally` around the relay loop, so every early return
  (instance resolve failure, connect-retry exhaustion) leaked a permanent +1 —
  the stats counter grows monotonically whenever containers are unreachable.
  The counter is now maintained by a try/finally around the whole handler body.
- **Guard the mid-retry instance re-resolutions** added in c9be162: if
  provisioning fails during a retry, the exception escaped as an unhandled
  500 / raw ASGI error. Now returns the existing 502 (HTTP) or closes with
  4003 (WebSocket).
- **Document the new settings** (`TERMINALS_STATUS_CACHE_TTL`,
  `TERMINALS_TOKEN_CACHE_TTL`, `TERMINALS_WS_COMPRESSION`,
  `TERMINALS_ACCESS_LOG`) in the README configuration table.

## Related Issues

<!-- link the performance issue here -->

## Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](./CLA.md), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
