### PR TITLE
fix: apply policy idle_timeout_minutes to containers adopted via reconcile()

### DIFF
--- a/terminals/backends/base.py
+++ b/terminals/backends/base.py
@@ -185,6 +185,46 @@ class Backend(ABC):
         await mark_terminal_active(user_id, policy_id)
         self._activity_synced_at[key] = time.monotonic()
 
+    async def _resolve_adopted_spec(self, policy_id: str) -> dict:
+        """Merged policy spec for an instance adopted by ``reconcile()``.
+
+        Returns ``{}`` when the policy can't be resolved (e.g. the implicit
+        "default" policy), matching a provision without a policy spec.
+        """
+        from fastapi import HTTPException
+
+        from terminals.routers.proxy import _resolve_policy_spec
+
+        try:
+            _, spec = await _resolve_policy_spec(policy_id)
+            return spec or {}
+        except HTTPException:
+            return {}
+        except Exception:
+            log.exception("Failed to resolve policy spec for %r", policy_id)
+            return {}
+
+    async def _seed_adopted_activity(
+        self, key: str, user_id: str, policy_id: str
+    ) -> None:
+        """Seed the idle clock for an adopted instance from the persisted
+        heartbeat, so a restart doesn't reset idle time already accrued.
+
+        Falls back to "now" when no heartbeat exists or the lookup fails.
+        """
+        self._record_activity(key)
+        try:
+            last_active = await terminal_last_active_at(user_id, policy_id)
+        except Exception:
+            log.exception("Failed to load persisted activity for %s", key)
+            return
+        if not last_active:
+            return
+        wall = last_active.replace(tzinfo=timezone.utc).timestamp()
+        if wall < self._activity_wall[key]:
+            self._activity_wall[key] = wall
+            self._activity[key] = time.monotonic() - (time.time() - wall)
+
     async def _apply_due_reset(
         self, user_id: str, policy_id: str, spec: Optional[dict]
     ) -> bool:

--- a/terminals/backends/docker.py
+++ b/terminals/backends/docker.py
@@ -6,7 +6,6 @@ import logging
 import re
 import secrets
 import shutil
-import time
 from pathlib import Path
 from typing import Optional
 
@@ -248,6 +247,7 @@ class DockerBackend(Backend):
         )
 
         recovered = 0
+        adopted_specs: dict[str, dict] = {}  # one lookup per distinct policy
         for container in containers:
             info = await container.show()
             name = info.get("Name", "").lstrip("/")
@@ -272,9 +272,11 @@ class DockerBackend(Backend):
                     break
 
             instance_info = await self._extract_instance_info(container, name, api_key)
+            if policy_id not in adopted_specs:
+                adopted_specs[policy_id] = await self._resolve_adopted_spec(policy_id)
             self._instances[key] = instance_info
-            self._activity[key] = time.monotonic()
-            self._activity_wall[key] = time.time()
+            self._specs[key] = adopted_specs[policy_id]
+            await self._seed_adopted_activity(key, user_id, policy_id)
             recovered += 1
             log.info("Reconciled container %s → %s:%s", name, instance_info["host"], instance_info["port"])
 

--- a/terminals/backends/kubernetes.py
+++ b/terminals/backends/kubernetes.py
@@ -6,7 +6,6 @@ import hashlib
 import logging
 import re
 import secrets
-import time
 from typing import Optional
 
 from kubernetes_asyncio import client, config
@@ -530,6 +529,8 @@ class KubernetesBackend(Backend):
             return
 
         recovered = 0
+        # The policy label holds a slug, so only DNS-safe policy ids resolve.
+        adopted_specs: dict[str, dict] = {}  # one lookup per distinct policy
         for pod in pods.items:
             if pod.status.phase not in ("Running", "Pending"):
                 continue
@@ -562,6 +563,9 @@ class KubernetesBackend(Backend):
                 log.debug("Pod %s has no API key secret, skipping", name)
                 continue
 
+            if policy_slug not in adopted_specs:
+                adopted_specs[policy_slug] = await self._resolve_adopted_spec(policy_slug)
+
             host = f"{name}.{ns}.svc.cluster.local"
             self._instances[key] = {
                 "instance_id": uid,
@@ -570,7 +574,8 @@ class KubernetesBackend(Backend):
                 "host": host,
                 "port": 8000,
             }
-            self._activity[key] = time.monotonic()
+            self._specs[key] = adopted_specs[policy_slug]
+            await self._seed_adopted_activity(key, user_id, policy_slug)
             recovered += 1
 
         if recovered:


### PR DESCRIPTION
After an orchestrator restart, reconcile() rebuilt _instances and _activity but never populated _specs, so re-adopted containers resolved their idle timeout via the settings.idle_timeout_minutes fallback (default 0 = disabled) and were skipped by the idle reaper forever. They leaked until the Docker bridge hit its 1024-port cap and provisioning broke.

Resolve the merged policy spec from the openwebui.com/policy label during reconciliation (one cached lookup per distinct policy) and store it in _specs, in both the Docker and Kubernetes backends. A policy that can't be resolved — e.g. the implicit "default" policy — degrades to an empty spec, matching a provision without a policy spec.

Also record wall-clock activity alongside the monotonic timestamp when adopting, so GET /api/v1/terminals no longer reports a null last_active_at for adopted containers. The idle clock still restarts at adoption time since last activity isn't persisted anywhere; adopted idle containers are now reaped after at most one full timeout window.

Fixes #45

## Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](./CLA.md), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
