### PR TITLE
fix: bound reaper sweep concurrency and per-operation time so one hung teardown can't stall it

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ All settings are configured through environment variables prefixed with `TERMINA
 | `TERMINALS_KUBERNETES_CONTAINER_SECURITY_CONTEXT` | | JSON container security context merged into Kubernetes terminal containers |
 | `TERMINALS_KUBERNETES_NODE_SELECTOR` | | Node selector for Kubernetes terminal and reset pods, as JSON or `k=v,k2=v2` |
 | `TERMINALS_KUBERNETES_TOLERATIONS` | | JSON array of Kubernetes tolerations for terminal and reset pods |
+| `TERMINALS_REAPER_CONCURRENCY` | `8` | Max instances the idle reaper tears down concurrently per sweep |
+| `TERMINALS_REAPER_OP_TIMEOUT_SECONDS` | `120` | Timeout for each teardown/reset call during a reaper sweep |
 | `TERMINALS_DATABASE_URL` | `sqlite+aiosqlite:///.../data/terminals.db` | SQLAlchemy database URL. SQLite is the default; PostgreSQL is optional. |
 | `TERMINALS_LOG_LEVEL` | `INFO` | Minimum orchestrator log level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`. On Docker, `WARNING` or higher disables child container Docker logs because Open Terminal does not expose a log-level env var. |
 | `TERMINALS_STATUS_CACHE_TTL` | `30` | Seconds a confirmed-running container status is trusted before re-inspecting it via the backend. `0` re-checks on every request. The cache is invalidated immediately when a proxied connection fails. |

--- a/terminals/backends/base.py
+++ b/terminals/backends/base.py
@@ -324,82 +324,142 @@ class Backend(ABC):
                 log.exception("Idle reaper error")
 
     async def _reap_idle(self) -> None:
-        """Scan tracked instances and tear down any that exceeded their timeout."""
+        """Apply due resets and tear down idle instances across the fleet.
+
+        Instances are processed concurrently with per-operation timeouts so
+        one slow or hung backend call can't stall the whole sweep.
+        """
+        keys = list(self._instances)
+        if not keys:
+            return
+
+        semaphore = asyncio.Semaphore(max(1, settings.reaper_concurrency))
+
+        async def _reap_one(key: str) -> None:
+            async with semaphore:
+                await self._reap_instance(key)
+
+        results = await asyncio.gather(
+            *(_reap_one(key) for key in keys), return_exceptions=True
+        )
+        for key, result in zip(keys, results):
+            if isinstance(result, BaseException):
+                log.error("Reaper task for %s failed: %r", key, result)
+
+    async def _reap_instance(self, key: str) -> None:
+        """Apply a due reset or idle-timeout teardown for one tracked instance."""
+        info = self._instances.get(key)
+        if info is None:
+            return
+
         now = time.monotonic()
+        op_timeout = settings.reaper_op_timeout_seconds
+        spec = self._specs.get(key, {})
+        user_id, policy_id = key.split(":", 1)
 
-        for key in list(self._instances):
-            info = self._instances.get(key)
-            if info is None:
-                continue
-
-            spec = self._specs.get(key, {})
-            user_id, policy_id = key.split(":", 1)
-            if await reset_due_for(user_id, policy_id, spec):
-                log.info(
-                    "Refreshing terminal %s for due reset (user=%s, policy=%s)",
-                    info.get("instance_name", info.get("instance_id")),
-                    user_id,
-                    policy_id,
-                )
-                try:
-                    await self.teardown(info["instance_id"])
-                except Exception:
-                    log.exception("Failed to tear down %s for scheduled reset", key)
-                try:
-                    await self.reset(user_id, policy_id, spec)
-                    await mark_reset_applied(user_id, policy_id, spec)
-                except NotImplementedError:
-                    log.warning("Reset due for %s but backend does not support it", key)
-                except Exception:
-                    log.exception("Failed to reset files for %s", key)
-                self._instances.pop(key, None)
-                self._specs.pop(key, None)
-                self._activity.pop(key, None)
-                self._activity_wall.pop(key, None)
-                self._running_checked_at.pop(key, None)
-                self._activity_synced_at.pop(key, None)
-                self._locks.pop(key, None)
-                continue
-
-            timeout_min = spec.get(
-                "idle_timeout_minutes", settings.idle_timeout_minutes
+        try:
+            reset_due = await asyncio.wait_for(
+                reset_due_for(user_id, policy_id, spec), op_timeout
             )
-            if not timeout_min or timeout_min <= 0:
-                continue
+        except Exception:
+            log.exception("Failed to check due reset for %s", key)
+            return
 
-            shared_last_active = await terminal_last_active_at(user_id, policy_id)
-            if shared_last_active:
-                shared_wall = shared_last_active.replace(tzinfo=timezone.utc).timestamp()
-                if shared_wall > self._activity_wall.get(key, 0):
-                    self._activity_wall[key] = shared_wall
-                    self._activity[key] = now
-
-            last_active = self._activity.get(key, now)
-            idle_seconds = now - last_active
-
-            if idle_seconds >= timeout_min * 60:
-                log.info(
-                    "Reaping idle terminal %s (user=%s, policy=%s, idle=%.0fs, timeout=%dm)",
-                    info.get("instance_name", info.get("instance_id")),
-                    user_id,
-                    policy_id,
-                    idle_seconds,
-                    timeout_min,
+        if reset_due:
+            log.info(
+                "Refreshing terminal %s for due reset (user=%s, policy=%s)",
+                info.get("instance_name", info.get("instance_id")),
+                user_id,
+                policy_id,
+            )
+            try:
+                await asyncio.wait_for(self.teardown(info["instance_id"]), op_timeout)
+            except asyncio.TimeoutError:
+                # State unknown — keep tracked so the next sweep retries.
+                log.error(
+                    "Teardown of %s timed out after %.0fs; will retry next sweep",
+                    key, op_timeout,
                 )
-                try:
-                    await self.teardown(info["instance_id"])
-                except Exception:
-                    log.exception("Failed to tear down %s", key)
-                try:
-                    await self._apply_due_reset(user_id, policy_id, spec)
-                except NotImplementedError:
-                    log.warning("Reset due for %s but backend does not support it", key)
-                except Exception:
-                    log.exception("Failed to reset files for %s", key)
-                self._instances.pop(key, None)
-                self._specs.pop(key, None)
-                self._activity.pop(key, None)
-                self._activity_wall.pop(key, None)
-                self._running_checked_at.pop(key, None)
-                self._activity_synced_at.pop(key, None)
-                self._locks.pop(key, None)
+                return
+            except Exception:
+                log.exception("Failed to tear down %s for scheduled reset", key)
+            try:
+                await asyncio.wait_for(self.reset(user_id, policy_id, spec), op_timeout)
+                await asyncio.wait_for(
+                    mark_reset_applied(user_id, policy_id, spec), op_timeout
+                )
+            except NotImplementedError:
+                log.warning("Reset due for %s but backend does not support it", key)
+            except asyncio.TimeoutError:
+                log.error("Reset for %s timed out after %.0fs", key, op_timeout)
+            except Exception:
+                log.exception("Failed to reset files for %s", key)
+            self._instances.pop(key, None)
+            self._specs.pop(key, None)
+            self._activity.pop(key, None)
+            self._activity_wall.pop(key, None)
+            self._running_checked_at.pop(key, None)
+            self._activity_synced_at.pop(key, None)
+            self._locks.pop(key, None)
+            return
+
+        timeout_min = spec.get(
+            "idle_timeout_minutes", settings.idle_timeout_minutes
+        )
+        if not timeout_min or timeout_min <= 0:
+            return
+
+        try:
+            shared_last_active = await asyncio.wait_for(
+                terminal_last_active_at(user_id, policy_id), op_timeout
+            )
+        except Exception:
+            log.exception("Failed to load persisted activity for %s", key)
+            shared_last_active = None
+        if shared_last_active:
+            shared_wall = shared_last_active.replace(tzinfo=timezone.utc).timestamp()
+            if shared_wall > self._activity_wall.get(key, 0):
+                self._activity_wall[key] = shared_wall
+                self._activity[key] = now
+
+        last_active = self._activity.get(key, now)
+        idle_seconds = now - last_active
+        if idle_seconds < timeout_min * 60:
+            return
+
+        log.info(
+            "Reaping idle terminal %s (user=%s, policy=%s, idle=%.0fs, timeout=%dm)",
+            info.get("instance_name", info.get("instance_id")),
+            user_id,
+            policy_id,
+            idle_seconds,
+            timeout_min,
+        )
+        try:
+            await asyncio.wait_for(self.teardown(info["instance_id"]), op_timeout)
+        except asyncio.TimeoutError:
+            # State unknown — keep tracked so the next sweep retries.
+            log.error(
+                "Teardown of %s timed out after %.0fs; will retry next sweep",
+                key, op_timeout,
+            )
+            return
+        except Exception:
+            log.exception("Failed to tear down %s", key)
+        try:
+            await asyncio.wait_for(
+                self._apply_due_reset(user_id, policy_id, spec), op_timeout
+            )
+        except NotImplementedError:
+            log.warning("Reset due for %s but backend does not support it", key)
+        except asyncio.TimeoutError:
+            log.error("Reset for %s timed out after %.0fs", key, op_timeout)
+        except Exception:
+            log.exception("Failed to reset files for %s", key)
+        self._instances.pop(key, None)
+        self._specs.pop(key, None)
+        self._activity.pop(key, None)
+        self._activity_wall.pop(key, None)
+        self._running_checked_at.pop(key, None)
+        self._activity_synced_at.pop(key, None)
+        self._locks.pop(key, None)

--- a/terminals/config.py
+++ b/terminals/config.py
@@ -74,6 +74,8 @@ class Settings(BaseSettings):
 
     # Idle reaper — tear down terminals after N minutes of inactivity (0 = disabled)
     idle_timeout_minutes: int = 0
+    reaper_concurrency: int = 8              # max concurrent reaps per sweep
+    reaper_op_timeout_seconds: float = 120   # per teardown/reset call
 
     # Policy hard caps (cannot be exceeded by API)
     max_cpu: str = ""              # TERMINALS_MAX_CPU


### PR DESCRIPTION
_reap_idle processed every tracked instance in a single sequential, timeout-less pass, and _reaper_loop awaits the full sweep before the next cycle. On large fleets, when a batch of scheduled resets came due at once, one slow or hung Docker/K8s call blocked the await and froze the entire loop with nothing logged — idle reaping and scheduled resets both silently stopped, and containers leaked until the Docker bridge hit its 1024-port cap. Only the provision-path reset kept working, so resets were applied only for reconnecting users.

Split the sweep into a cheap scan that collects due instances, then reap them concurrently under a semaphore (TERMINALS_REAPER_CONCURRENCY, default 8) with a timeout on each teardown/reset call (TERMINALS_REAPER_OP_TIMEOUT_SECONDS, default 120). A timed-out teardown is logged and the instance stays tracked so the next sweep retries it, rather than orphaning a possibly-still-running container. Worst-case sweep duration is now bounded instead of unbounded.

Fixes #46

## Contributor License Agreement

<!--
🚨 DO NOT DELETE THE TEXT BELOW 🚨
Keep the "Contributor License Agreement" confirmation text intact.
Deleting it will trigger the CLA-Bot to INVALIDATE your PR.

Your PR will NOT be reviewed or merged until you check the box below confirming that you have read and agree to the terms of the CLA.
-->

- [x] By submitting this pull request, I confirm that I have read and fully agree to the [Contributor License Agreement (CLA)](./CLA.md), and I am providing my contributions under its terms.

> [!NOTE]
> Deleting the CLA section will lead to immediate closure of your PR and it will not be merged in.
